### PR TITLE
Fix unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,4 +187,4 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--ignore=qim3d/tests/notebooks -p no:warnings"
+addopts = "-p no:warnings"       # "--ignore=qim3d/tests/notebooks -p no:warnings"

--- a/qim3d/generate/_aggregators.py
+++ b/qim3d/generate/_aggregators.py
@@ -501,7 +501,8 @@ def volume_collection(
         import qim3d
 
         # Generate synthetic collection of volumes
-        volume_collection, labels = qim3d.generate.volume_collection(num_volumes=15)
+        num_volumes = 15
+        volume_collection, labels = qim3d.generate.volume_collection(num_volumes=num_volumes)
 
         # Visualize the collection
         qim3d.viz.volumetric(volume_collection, grid_visible=True)

--- a/qim3d/generate/_generators.py
+++ b/qim3d/generate/_generators.py
@@ -451,14 +451,13 @@ def volume(
         final_shape (tuple of ints, optional): Desired shape of the final volume. If unspecified, will assume same shape as base_shape. Defaults to None.
         noise_scale (float, optional): Scale factor for Perlin noise. Defaults to 0.05.
         noise_type (str, optional): Type of noise to be used for volume generation. Should be `simplex` or `perlin`. Defaults to perlin.
-
         decay_rate (float, optional): The decay rate of the fading of the noise. Can also be interpreted as the sharpness of the edge of the volume. Defaults to 5.0.
         gamma (float, optional): Applies gamma correction, adjusting contrast in the volume. If gamma<0, the volume intensity is increased and if gamma>0 it's decreased. Defaults to 0.
         threshold (float, optional): Threshold value for clipping low intensity values. Defaults to 0.5.
         max_value (int, optional): Maximum value for the volume intensity. Defaults to 255.
         shape (str, optional): Shape of the volume to generate, either `cylinder`, or `tube`. Defaults to None.
         tube_hole_ratio (float, optional): Ratio for the inverted fade mask used to generate tubes. Will only have an effect if shape=`tube`. Defaults to 0.5.
-        axis (int, optional): Axis of the given volume_shape. Will only be active if volume_shape is defined. Defaults to 0.
+        axis (int, optional): Axis of the given shape. Will only be active if shape is defined. Defaults to 0.
         order (int, optional): Order of the spline interpolation used in resizing. Defaults to 1.
         dtype (data-type, optional): Desired data type of the output volume. Defaults to `uint8`.
         hollow (bool, optional): Determines thickness of the hollowing operation. Volume is only hollowed if hollow>0. Defaults to 0.
@@ -530,7 +529,7 @@ def volume(
                                 noise_scale = 0.03,
                                 gamma = 0.12,
                                 threshold = 0.85,
-                                volume_shape = "tube"
+                                shape = "tube",
                                 )
 
         # Visualize synthetic blob

--- a/qim3d/tests/data_handling/test_generate.py
+++ b/qim3d/tests/data_handling/test_generate.py
@@ -7,9 +7,7 @@ import qim3d
 # Unit test for background() apply_to ValueError
 def test_background_apply_to_error():
     background_shape = (64, 64, 64)
-    apply_method = 'add'
-
-    msg = f"apply_method '{apply_method}' is only supported when apply_to input volume is provided."
+    msg = f"Supply both apply_method and apply_to when applying background to a volume."
 
     with pytest.raises(ValueError, match=msg):
         qim3d.generate.background(background_shape=background_shape, apply_method='add')

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -3,7 +3,7 @@
 import math
 import warnings
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, Dict, Any
 
 import dask.array as da
 import matplotlib
@@ -1248,7 +1248,7 @@ def line_profile(
     slice_index: int | str = 'middle',
     vertical_position: int | str = 'middle',
     horizontal_position: int | str = 'middle',
-    angle: int = 0,
+    angle: int = 0.0,
     fraction_range: tuple[float, float] = (0.00, 1.00),
     y_limits: str | tuple[float, float] = 'auto',
 ) -> widgets.interactive:


### PR DESCRIPTION
**Notion**: https://www.notion.so/qim-dtu/Fix-unit-tests-1fcbab83b2f9807096bad76900598f82

Failed unit tests have been fixed. Also, the flag for ignoring the notebooks unit tests by default has been removed in `pyproject.toml`. Therefore, now when running `pytest qim3d/tests/`, all unit tests are run (including notebooks unit tests). 