### PR TITLE
Vol comparison

### DIFF
--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -1,6 +1,7 @@
 """Provides a collection of visualization functions."""
 
 import math
+import time
 import warnings
 from collections.abc import Sequence
 from typing import Literal
@@ -1574,11 +1575,16 @@ class _VolumeComparison:
         volume2: np.ndarray | da.core.Array,
         slice_axis: int,
         slice_index: int,
+        k3d: bool = False,
     ) -> None:
         self.volume1 = volume1
         self.volume2 = volume2
         self.slice_axis = slice_axis
         self.slice_index = slice_index
+        self.k3d = k3d
+        self.plot_output1 = widgets.Output()
+        self.plot_output2 = widgets.Output()
+        self.plot_output3 = widgets.Output()
         self.color_map = 'bwr'
         self.comparison_type = 'difference'
 
@@ -1588,6 +1594,31 @@ class _VolumeComparison:
         self.initialize_widgets()
         self.update_slice_axis(slice_axis)
         self.slice_index_widget.value = slice_index
+        if self.k3d:
+            self.initialize_k3d_plots()
+
+    def initialize_k3d_plots(self) -> None:
+        self.k3d_plot1 = qim3d.viz.volumetric(
+            self.volume1,
+            show=False,
+        )
+        self.k3d_plot2 = qim3d.viz.volumetric(
+            self.volume2,
+            show=False,
+        )
+        # Difference defaults to simple subtraction difference
+        alpha = [
+            [-1.0, 1.0],  # fully opaque at -255
+            [-0.3, 0.0],  # fade out to transparent near -76
+            [0.3, 0.0],  # fade out to transparent near +76
+            [1.0, 1.0],  # fully opaque at +255
+        ]
+        self.k3d_plot3 = qim3d.viz.volumetric(
+            (self.volume1 - self.volume2),
+            show=False,
+            color_map='bwr',
+            opacity_function=alpha,
+        )
 
     def update_slice_axis(self, slice_axis: int) -> None:
         self.slice_axis = slice_axis
@@ -1636,7 +1667,6 @@ class _VolumeComparison:
         )
         mappable01 = matplotlib.cm.ScalarMappable(norm=norm01)
 
-        self.comparison_type = comparison_type
         if comparison_type == 'difference':
             comparison = slice1 - slice2
             vrange = [comparison.min(), comparison.max()]
@@ -1648,15 +1678,52 @@ class _VolumeComparison:
                 vmax=max(0.0 + eps, vrange[1]),
             )
             color_map = 'bwr'
+            if self.comparison_type != comparison_type and self.k3d:
+                # Update difference k3d plot
+                alpha = [
+                    [-1.0, 1.0],  # fully opaque at -255
+                    [-0.3, 0.0],  # fade out to transparent near -76
+                    [0.3, 0.0],  # fade out to transparent near +76
+                    [1.0, 1.0],  # fully opaque at +255
+                ]
+                self.k3d_plot3 = qim3d.viz.volumetric(
+                    self.volume1 - self.volume2,
+                    show=False,
+                    color_map=color_map,
+                    opacity_function=alpha,
+                )
+                self.plot_output3.clear_output()
+                with self.plot_output3:
+                    display(self.k3d_plot3)
         else:
             if comparison_type == 'absolute difference':
                 comparison = np.abs(slice1 - slice2)
+                if self.comparison_type != comparison_type and self.k3d:
+                    # Update difference k3d plot
+                    self.k3d_plot3 = qim3d.viz.volumetric(
+                        np.abs(self.volume1 - self.volume2),
+                        show=False,
+                    )
+                    self.plot_output3.clear_output()
+                    with self.plot_output3:
+                        display(self.k3d_plot3)
             elif comparison_type == 'quadratic difference':
                 comparison = (slice1 - slice2) ** 2
+                if self.comparison_type != comparison_type and self.k3d:
+                    # Update difference k3d plot
+                    self.k3d_plot3 = qim3d.viz.volumetric(
+                        (self.volume1 - self.volume2) ** 2,
+                        show=False,
+                    )
+                    self.plot_output3.clear_output()
+                    with self.plot_output3:
+                        display(self.k3d_plot3)
 
             vrange = [0.0, comparison.max()]
             norm2 = matplotlib.colors.Normalize(vmin=vrange[0], vmax=vrange[1])
             color_map = 'magma'
+
+        self.comparison_type = comparison_type
 
         nc = 256
         lb = round(color_range[0] * nc)
@@ -1732,7 +1799,45 @@ class _VolumeComparison:
             },
         )
 
-        return widgets.VBox([controls, interactive_plot])
+        if self.k3d:
+            shared_layout = widgets.Layout(
+                width='100%',  # Ensures each Output takes full width of its box
+                height='550px',  # Fixed height to help WebGL rendering
+                border='1px solid lightgray',
+                overflow='hidden',
+                margin='0 10px 0 0',
+                flex='1 1 0%',  # Allow side-by-side stretch
+                min_width='300px',
+            )
+
+            self.plot_output1.layout = shared_layout
+            self.plot_output2.layout = shared_layout
+            self.plot_output3.layout = shared_layout
+
+            k3d_plot = widgets.HBox(
+                [self.plot_output1, self.plot_output2, self.plot_output3],
+                layout=widgets.Layout(
+                    width='1200px',
+                    display='flex',
+                    flex_flow='row',
+                    align_items='stretch',
+                    justify_content='space-between',
+                ),
+            )
+
+            with self.plot_output1:
+                display(self.k3d_plot1)
+            time.sleep(0.1)
+            with self.plot_output2:
+                display(self.k3d_plot2)
+            time.sleep(0.1)
+            with self.plot_output3:
+                display(self.k3d_plot3)
+            time.sleep(0.1)
+        else:
+            k3d_plot = widgets.HBox([])
+
+        return widgets.VBox([controls, interactive_plot, k3d_plot])
 
 
 def compare_volumes(
@@ -1740,6 +1845,7 @@ def compare_volumes(
     volume2: np.ndarray,
     slice_axis: int = 0,
     slice_index: int = None,
+    k3d: bool = False,
 ) -> widgets.interactive:
     """
     Returns an interactive widget for comparing two volumes along slices.
@@ -1749,6 +1855,7 @@ def compare_volumes(
         volume2 (np.ndarray): The second volume.
         slice_axis (int, optional): Specifies the initial axis along which to slice.
         slice_index (int, optional): Specifies the initial index along slice_axis.
+        k3d (bool, optional): Defines if k3d plots should also be shown.
 
     Returns:
         widget (widgets.widget_box.VBox): The interactive widget.
@@ -1786,5 +1893,5 @@ def compare_volumes(
         msg = 'slice_index must be an integer.'
         raise ValueError(msg)
 
-    vc = _VolumeComparison(volume1, volume2, slice_axis, slice_index)
+    vc = _VolumeComparison(volume1, volume2, slice_axis, slice_index, k3d)
     return vc.build_interactive()

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -1,7 +1,6 @@
 """Provides a collection of visualization functions."""
 
 import math
-import time
 import warnings
 from collections.abc import Sequence
 from typing import Literal
@@ -17,7 +16,9 @@ import zarr
 from IPython.display import clear_output, display
 from ipywidgets import widgets
 from ipywidgets.widgets import Output, Widget
+from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.figure import Figure
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from skimage.filters import (
     threshold_isodata,
     threshold_li,
@@ -29,6 +30,7 @@ from skimage.filters import (
 )
 
 import qim3d
+from qim3d.utils._logger import log
 
 
 def slices_grid(
@@ -1582,41 +1584,49 @@ class _VolumeComparison:
         self.slice_axis = slice_axis
         self.slice_index = slice_index
         self.k3d = k3d
-        self.plot_output1 = widgets.Output()
-        self.plot_output2 = widgets.Output()
-        self.plot_output3 = widgets.Output()
-        self.color_map = 'bwr'
-        self.comparison_type = 'difference'
 
-        self.dims = np.array(volume1.shape)
-        self.cbar_pad = 0.1
+        self.k3d_output1 = widgets.Output()  # Pre-initialize the widget outputs
+        self.k3d_output2 = widgets.Output()  # Pre-initialize the widget outputs
+        self.k3d_output3 = widgets.Output()  # Pre-initialize the widget outputs
+        self.plt_output1 = widgets.Output()  # Pre-initialize the widget outputs
+        self.plt_output2 = widgets.Output()  # Pre-initialize the widget outputs
+        self.plt_output3 = widgets.Output()  # Pre-initialize the widget outputs
 
+        self.update_comp_plot = False  # Bool flag for unnecessary plot updates
+        self.update_plots = False  # Bool flag for unnecessary plot updates
+        self.comparison_type = 'difference'  # Default comparison type
+
+        self.create_colormap()
         self.initialize_widgets()
         self.update_slice_axis(slice_axis)
         self.slice_index_widget.value = slice_index
         if self.k3d:
             self.initialize_k3d_plots()
 
+    def create_colormap(self) -> None:
+        # Combine Blues and Reds colormaps
+        blues = plt.cm.Blues_r(np.linspace(0.0, 1, 256))
+        reds = plt.cm.Reds(np.linspace(0.0, 1, 256))
+        colors = np.vstack((blues, reds))
+        self.diff_cmap = LinearSegmentedColormap.from_list('blue_red', colors)
+
     def initialize_k3d_plots(self) -> None:
         self.k3d_plot1 = qim3d.viz.volumetric(
-            self.volume1,
-            show=False,
+            self.volume1, show=False, color_map='Reds'
         )
         self.k3d_plot2 = qim3d.viz.volumetric(
-            self.volume2,
-            show=False,
+            self.volume2, show=False, color_map='Blues'
         )
-        # Difference defaults to simple subtraction difference
         alpha = [
-            [-1.0, 1.0],  # fully opaque at -255
-            [-0.3, 0.0],  # fade out to transparent near -76
-            [0.3, 0.0],  # fade out to transparent near +76
-            [1.0, 1.0],  # fully opaque at +255
+            [0.0, 1.0],
+            [0.35, 0.0],
+            [0.65, 0.0],
+            [1, 1.0],
         ]
         self.k3d_plot3 = qim3d.viz.volumetric(
             (self.volume1 - self.volume2),
             show=False,
-            color_map='bwr',
+            color_map=self.diff_cmap,
             opacity_function=alpha,
         )
 
@@ -1646,6 +1656,18 @@ class _VolumeComparison:
         )
         self.slice_index_widget.layout.width = '400px'
 
+    def slice_cmap(
+        self, cmap: str | LinearSegmentedColormap, color_range: tuple[float, float]
+    ) -> matplotlib.colors.ListedColormap:
+        if isinstance(cmap, str):
+            cmap = matplotlib.colormaps[cmap].resampled(256)
+        black = np.array([0, 0, 0, 1])
+        sampled_colors = cmap(np.linspace(0, 1, 256))
+        sampled_colors[: round(color_range[0] * 256), :] = black
+        sampled_colors[round(color_range[1] * 256) :, :] = black
+        newcmp = matplotlib.colors.ListedColormap(sampled_colors)
+        return newcmp
+
     def update(
         self,
         slice_axis: int,
@@ -1657,17 +1679,18 @@ class _VolumeComparison:
             self.update_slice_axis(slice_axis)
             slice_index = self.slice_index_widget.value
 
-        clear_output(wait=True)
         slice1 = np.take(self.volume1, slice_index, axis=slice_axis).astype(float)
         slice2 = np.take(self.volume2, slice_index, axis=slice_axis).astype(float)
-        fig, ax = plt.subplots(1, 3, figsize=(12, 5))
 
-        norm01 = matplotlib.colors.Normalize(
+        norm1 = matplotlib.colors.Normalize(
             vmin=min(slice1.min(), slice2.min()), vmax=max(slice1.max(), slice2.max())
         )
-        mappable01 = matplotlib.cm.ScalarMappable(norm=norm01)
 
         if comparison_type == 'difference':
+            newcmp = self.slice_cmap(self.diff_cmap, color_range)
+            cmap1 = self.slice_cmap('Reds', color_range)
+            cmap2 = self.slice_cmap('Blues', color_range)
+
             comparison = slice1 - slice2
             vrange = [comparison.min(), comparison.max()]
             # In the special cases add small epsilon since TwoSlopeNorm requires vmin, vcenter, vmax to be in strictly ascending order.
@@ -1677,87 +1700,141 @@ class _VolumeComparison:
                 vcenter=0.0,
                 vmax=max(0.0 + eps, vrange[1]),
             )
-            color_map = 'bwr'
+            # Create opacity function for k3d comparison plot
+            alpha = [
+                [0.0, 1.0],
+                [0.35, 0.0],
+                [0.65, 0.0],
+                [1, 1.0],
+            ]
+            # Create comparison k3d plot
             if self.comparison_type != comparison_type and self.k3d:
-                # Update difference k3d plot
-                alpha = [
-                    [-1.0, 1.0],  # fully opaque at -255
-                    [-0.3, 0.0],  # fade out to transparent near -76
-                    [0.3, 0.0],  # fade out to transparent near +76
-                    [1.0, 1.0],  # fully opaque at +255
-                ]
-                self.k3d_plot3 = qim3d.viz.volumetric(
-                    self.volume1 - self.volume2,
-                    show=False,
-                    color_map=color_map,
-                    opacity_function=alpha,
-                )
-                self.plot_output3.clear_output()
-                with self.plot_output3:
-                    display(self.k3d_plot3)
+                comparison_k3d = self.volume1 - self.volume2
+
         else:
+            newcmp = self.slice_cmap('magma', color_range)
+            cmap1 = newcmp
+            cmap2 = newcmp
+            alpha = []
+
             if comparison_type == 'absolute difference':
                 comparison = np.abs(slice1 - slice2)
                 if self.comparison_type != comparison_type and self.k3d:
-                    # Update difference k3d plot
-                    self.k3d_plot3 = qim3d.viz.volumetric(
-                        np.abs(self.volume1 - self.volume2),
-                        show=False,
-                    )
-                    self.plot_output3.clear_output()
-                    with self.plot_output3:
-                        display(self.k3d_plot3)
+                    comparison_k3d = np.abs(self.volume1 - self.volume2)
+
             elif comparison_type == 'quadratic difference':
                 comparison = (slice1 - slice2) ** 2
                 if self.comparison_type != comparison_type and self.k3d:
-                    # Update difference k3d plot
-                    self.k3d_plot3 = qim3d.viz.volumetric(
-                        (self.volume1 - self.volume2) ** 2,
-                        show=False,
-                    )
-                    self.plot_output3.clear_output()
-                    with self.plot_output3:
-                        display(self.k3d_plot3)
+                    comparison_k3d = (self.volume1 - self.volume2) ** 2
 
             vrange = [0.0, comparison.max()]
             norm2 = matplotlib.colors.Normalize(vmin=vrange[0], vmax=vrange[1])
-            color_map = 'magma'
 
+        if self.comparison_type != comparison_type and self.k3d:
+            # Update difference k3d plot
+            self.k3d_plot3 = qim3d.viz.volumetric(
+                comparison_k3d,
+                show=False,
+                color_map=self.diff_cmap
+                if comparison_type == 'difference'
+                else 'magma',
+                opacity_function=alpha,
+            )
+            self.update_comp_plot = True
+
+            if (
+                comparison_type == 'difference'
+                or (
+                    'quadratic' in comparison_type
+                    and 'absolute' not in self.comparison_type
+                )
+                or (
+                    'absolute' in comparison_type
+                    and 'quadratic' not in self.comparison_type
+                )
+            ):
+                # Update k3d plots 1 and 2 if colormap change is necessary (difference <-> quadratic/absolute)
+                self.k3d_plot1 = qim3d.viz.volumetric(
+                    self.volume1,
+                    show=False,
+                    color_map='Blues' if comparison_type == 'difference' else 'magma',
+                )
+                self.k3d_plot2 = qim3d.viz.volumetric(
+                    self.volume2,
+                    show=False,
+                    color_map='Reds' if comparison_type == 'difference' else 'magma',
+                )
+                self.update_plots = True
+
+        # Overwrite the comparison type in instance
         self.comparison_type = comparison_type
 
-        nc = 256
-        lb = round(color_range[0] * nc)
-        ub = round(color_range[1] * nc)
+        # Create plots
+        fig_1, ax_1 = plt.subplots(figsize=(4, 4))
+        im1 = ax_1.imshow(slice1, norm=norm1, cmap=cmap1)
+        ax_1.set_title('Volume1')
+        divider1 = make_axes_locatable(ax_1)
+        cax1 = divider1.append_axes('bottom', size='5%', pad=0.3)
+        fig_1.colorbar(im1, cax=cax1, orientation='horizontal')
+        fig_1.tight_layout()
+        self.fig1 = fig_1
+        plt.close(fig_1)
 
-        cmap_obj = matplotlib.colormaps[color_map].resampled(nc)
-        newcolors = cmap_obj(np.linspace(0, 1, nc))
-        black = np.array([0, 0, 0, 1])
-        newcolors[:lb, :] = black
-        newcolors[ub:, :] = black
-        newcmp = matplotlib.colors.ListedColormap(newcolors)
+        fig_2, ax_2 = plt.subplots(figsize=(4, 4))
+        im2 = ax_2.imshow(slice2, norm=norm1, cmap=cmap2)
+        ax_2.set_title('Volume2')
+        divider2 = make_axes_locatable(ax_2)
+        cax2 = divider2.append_axes('bottom', size='5%', pad=0.3)
+        fig_2.colorbar(im2, cax=cax2, orientation='horizontal')
+        fig_2.tight_layout()
+        self.fig2 = fig_2
+        plt.close(fig_2)
 
-        mappable2 = matplotlib.cm.ScalarMappable(norm=norm2, cmap=newcmp)
+        fig_3, ax_3 = plt.subplots(figsize=(4, 4))
+        im3 = ax_3.imshow(comparison, norm=norm2, cmap=newcmp)
+        ax_3.set_title(comparison_type)
+        divider3 = make_axes_locatable(ax_3)
+        cax3 = divider3.append_axes('bottom', size='5%', pad=0.3)
+        fig_3.colorbar(im3, cax=cax3, orientation='horizontal')
+        fig_3.tight_layout()
+        self.fig3 = fig_3
+        plt.close(fig_3)
 
-        ax[0].imshow(slice1, norm=norm01)
-        ax[0].set_title('volume1')
-        fig.colorbar(
-            mappable=mappable01, ax=ax[0], orientation='horizontal', pad=self.cbar_pad
-        )
+        # Visualize plt plot 1
+        self.plt_output1.clear_output(wait=True)
+        with self.plt_output1:
+            plt.figure(self.fig1)
+            plt.show()
 
-        ax[1].imshow(slice2, norm=norm01)
-        ax[1].set_title('volume2')
-        fig.colorbar(
-            mappable=mappable01, ax=ax[1], orientation='horizontal', pad=self.cbar_pad
-        )
+        # Visualize plt plot 2
+        self.plt_output2.clear_output(wait=True)
+        with self.plt_output2:
+            plt.figure(self.fig2)
+            plt.show()
 
-        ax[2].imshow(comparison, norm=norm2, cmap=newcmp)
-        ax[2].set_title(comparison_type)
-        fig.colorbar(
-            mappable=mappable2, ax=ax[2], orientation='horizontal', pad=self.cbar_pad
-        )
+        # Visualize plt plot 3
+        self.plt_output3.clear_output(wait=True)
+        with self.plt_output3:
+            plt.figure(self.fig3)
+            plt.show()
 
-        fig.tight_layout()
-        plt.show()
+        if self.update_plots:
+            # Visualize k3d plot 1 (if there are changes)
+            self.k3d_output1.clear_output(wait=True)
+            with self.k3d_output1:
+                display(self.k3d_plot1)
+            # Visualize k3d plot 1 (if there are changes)
+            self.k3d_output2.clear_output(wait=True)
+            with self.k3d_output2:
+                display(self.k3d_plot2)
+            self.update_plots = False
+
+        # Visualize k3d plot 3 (if there are changes)
+        if self.update_comp_plot:
+            self.k3d_output3.clear_output(wait=True)
+            with self.k3d_output3:
+                display(self.k3d_plot3)
+            self.update_comp_plot = False
 
     def build_interactive(self) -> widgets.VBox:
         # Group widgets into two columns
@@ -1799,45 +1876,88 @@ class _VolumeComparison:
             },
         )
 
+        # Create height on plt outputs to prevent flickering
+        plt_layout = widgets.Layout(
+            height='400px',
+            width='99%',
+            overflow='hidden',
+            border='1px solid black',
+        )
+
+        fig_layout = widgets.Layout(
+            width='400px',
+            height='100%',
+            display='flex',
+            flex_flow='column',
+            align_items='stretch',
+            justify_content='space-between',
+        )
+        self.plt_output1.layout = plt_layout
+        self.plt_output2.layout = plt_layout
+        self.plt_output3.layout = plt_layout
+
         if self.k3d:
-            shared_layout = widgets.Layout(
-                width='100%',  # Ensures each Output takes full width of its box
-                height='550px',  # Fixed height to help WebGL rendering
-                border='1px solid lightgray',
+            k3d_layout = widgets.Layout(
+                width='99%',  # Slightly smaller
+                height='400px',
                 overflow='hidden',
-                margin='0 10px 0 0',
-                flex='1 1 0%',  # Allow side-by-side stretch
-                min_width='300px',
+                flex='1 1 0%',
+                border='1px solid black',
             )
 
-            self.plot_output1.layout = shared_layout
-            self.plot_output2.layout = shared_layout
-            self.plot_output3.layout = shared_layout
+            self.k3d_output1.layout = k3d_layout
+            self.k3d_output2.layout = k3d_layout
+            self.k3d_output3.layout = k3d_layout
 
-            k3d_plot = widgets.HBox(
-                [self.plot_output1, self.plot_output2, self.plot_output3],
-                layout=widgets.Layout(
-                    width='1200px',
-                    display='flex',
-                    flex_flow='row',
-                    align_items='stretch',
-                    justify_content='space-between',
-                ),
+            fig1 = widgets.VBox(
+                [self.plt_output1, self.k3d_output1],
+                layout=fig_layout,
+            )
+            fig2 = widgets.VBox(
+                [self.plt_output2, self.k3d_output2],
+                layout=fig_layout,
+            )
+            fig3 = widgets.VBox(
+                [self.plt_output3, self.k3d_output3],
+                layout=fig_layout,
             )
 
-            with self.plot_output1:
+            with self.k3d_output1:
                 display(self.k3d_plot1)
-            time.sleep(0.1)
-            with self.plot_output2:
+            with self.k3d_output2:
                 display(self.k3d_plot2)
-            time.sleep(0.1)
-            with self.plot_output3:
+            with self.k3d_output3:
                 display(self.k3d_plot3)
-            time.sleep(0.1)
-        else:
-            k3d_plot = widgets.HBox([])
+        else:  # if volumetric visualization should not  be shown
+            fig1 = widgets.VBox(
+                [self.plt_output1],
+                layout=fig_layout,
+            )
+            fig2 = widgets.VBox(
+                [self.plt_output2],
+                layout=fig_layout,
+            )
+            fig3 = widgets.VBox(
+                [self.plt_output3],
+                layout=fig_layout,
+            )
 
-        return widgets.VBox([controls, interactive_plot, k3d_plot])
+        # Update visualization and return the widgets
+        self.plt_output1.clear_output(wait=True)
+        self.plt_output2.clear_output(wait=True)
+        self.plt_output3.clear_output(wait=True)
+        with self.plt_output1:
+            plt.figure(self.fig1)
+            plt.show()
+        with self.plt_output2:
+            plt.figure(self.fig2)
+            plt.show()
+        with self.plt_output3:
+            plt.figure(self.fig3)
+            plt.show()
+
+        figs = widgets.HBox([fig1, fig2, fig3])
+        return widgets.VBox([controls, interactive_plot, figs])
 
 
 def compare_volumes(
@@ -1882,6 +2002,13 @@ def compare_volumes(
     if volume1.shape != volume2.shape:
         msg = 'Volumes must have the same shape.'
         raise ValueError(msg)
+
+    if np.issubdtype(volume1.dtype, np.unsignedinteger) and np.issubdtype(
+        volume2.dtype, np.unsignedinteger
+    ):
+        log.warning(
+            'Volumes have unsigned integer datatypes. Beware of over-/underflow.'
+        )
 
     if slice_axis not in (0, 1, 2):
         msg = 'Invalid slice_axis.'

--- a/qim3d/viz/_k3d.py
+++ b/qim3d/viz/_k3d.py
@@ -49,7 +49,7 @@ def volumetric(
             file will be saved. Defaults to False.
         grid_visible (bool, optional): If True, the grid is visible in the plot. Defaults to False.
         color_map (str or matplotlib.colors.Colormap or list, optional): The color map to be used for the volume rendering. If a string is passed, it should be a matplotlib colormap name. Defaults to 'magma'.
-        constant_opacity (bool, optional): Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to False.
+        constant_opacity (bool): Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to False.
         opacity_function (str or list, optional): Applies an opacity function to the plot, enabling custom values for opaqueness. Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to [].
         vmin (float or None, optional): Together with vmax defines the data range the colormap covers. By default colormap covers the full range. Defaults to None.
         vmax (float or None, optional): Together with vmin defines the data range the colormap covers. By default colormap covers the full range. Defaults to None

--- a/qim3d/viz/_k3d.py
+++ b/qim3d/viz/_k3d.py
@@ -26,6 +26,7 @@ def volumetric(
     save: bool = False,
     grid_visible: bool = False,
     color_map: str = 'magma',
+    constant_opacity: bool = False,
     opacity_function: str | list = None,
     vmin: float | None = None,
     vmax: float | None = None,
@@ -48,7 +49,8 @@ def volumetric(
             file will be saved. Defaults to False.
         grid_visible (bool, optional): If True, the grid is visible in the plot. Defaults to False.
         color_map (str or matplotlib.colors.Colormap or list, optional): The color map to be used for the volume rendering. If a string is passed, it should be a matplotlib colormap name. Defaults to 'magma'.
-        opacity_function (str or list): Applies an opacity function to the plot, enabling custom values for opaqueness. Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to [].
+        constant_opacity (bool, optional): Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to False.
+        opacity_function (str or list, optional): Applies an opacity function to the plot, enabling custom values for opaqueness. Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to [].
         vmin (float or None, optional): Together with vmax defines the data range the colormap covers. By default colormap covers the full range. Defaults to None.
         vmax (float or None, optional): Together with vmin defines the data range the colormap covers. By default colormap covers the full range. Defaults to None
         samples (int or 'auto', optional): The number of samples to be used for the volume rendering in k3d. Input 'auto' for auto selection. Defaults to 'auto'.
@@ -144,12 +146,21 @@ def volumetric(
 
     # Default k3d.volume settings
     interpolation = True
-    if opacity_function == 'constant':
+
+    if constant_opacity:
+        log.warning(
+            'Deprecation warning: Keyword argument "constant_opacity" is deprecated and will be removed next release. Instead use opacity_function="constant".'
+        )
         # without these settings, the plot will look bad when color_map is created with qim3d.viz.colormaps.objects
-        opacity_function = [0.0, float(True), 1.0, float(True)]
+        opacity_function = [0.0, float(constant_opacity), 1.0, float(constant_opacity)]
         interpolation = False
-    elif opacity_function is None:
-        opacity_function = []
+    else:
+        if opacity_function == 'constant':
+            # without these settings, the plot will look bad when color_map is created with qim3d.viz.colormaps.objects
+            opacity_function = [0.0, float(True), 1.0, float(True)]
+            interpolation = False
+        elif opacity_function is None:
+            opacity_function = []
 
     # Create the volume plot
     plt_volume = k3d.volume(

--- a/qim3d/viz/_k3d.py
+++ b/qim3d/viz/_k3d.py
@@ -7,8 +7,6 @@ Volumetric visualization using K3D.
 
 """
 
-from typing import Optional, Union
-
 import k3d
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,14 +26,14 @@ def volumetric(
     save: bool = False,
     grid_visible: bool = False,
     color_map: str = 'magma',
-    constant_opacity: bool = False,
+    opacity_function: str | list = None,
     vmin: float | None = None,
     vmax: float | None = None,
     samples: int | str = 'auto',
     max_voxels: int = 512**3,
     data_type: str = 'scaled_float16',
     **kwargs,
-) -> Optional[k3d.Plot]:
+) -> k3d.Plot | None:
     """
     Visualizes a 3D volume using volumetric rendering.
 
@@ -50,7 +48,7 @@ def volumetric(
             file will be saved. Defaults to False.
         grid_visible (bool, optional): If True, the grid is visible in the plot. Defaults to False.
         color_map (str or matplotlib.colors.Colormap or list, optional): The color map to be used for the volume rendering. If a string is passed, it should be a matplotlib colormap name. Defaults to 'magma'.
-        constant_opacity (bool): Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to False.
+        opacity_function (str or list): Applies an opacity function to the plot, enabling custom values for opaqueness. Set to True if doing an object label visualization with a corresponding color_map; otherwise, the plot may appear poorly. Defaults to [].
         vmin (float or None, optional): Together with vmax defines the data range the colormap covers. By default colormap covers the full range. Defaults to None.
         vmax (float or None, optional): Together with vmin defines the data range the colormap covers. By default colormap covers the full range. Defaults to None
         samples (int or 'auto', optional): The number of samples to be used for the volume rendering in k3d. Input 'auto' for auto selection. Defaults to 'auto'.
@@ -145,12 +143,13 @@ def volumetric(
             color_map = np.column_stack((attr_vals, rgb_vals)).tolist()
 
     # Default k3d.volume settings
-    opacity_function = []
     interpolation = True
-    if constant_opacity:
+    if opacity_function == 'constant':
         # without these settings, the plot will look bad when color_map is created with qim3d.viz.colormaps.objects
-        opacity_function = [0.0, float(constant_opacity), 1.0, float(constant_opacity)]
+        opacity_function = [0.0, float(True), 1.0, float(True)]
         interpolation = False
+    elif opacity_function is None:
+        opacity_function = []
 
     # Create the volume plot
     plt_volume = k3d.volume(
@@ -188,7 +187,7 @@ def mesh(
     show: bool = True,
     save: bool = False,
     **kwargs,
-) -> Optional[Union[k3d.Plot, go.FigureWidget]]:
+) -> k3d.Plot | go.FigureWidget | None:
     """
     Visualize a 3D mesh using `pygel3d` or `k3d`. The visualization with the pygel3d backend provides higher-quality rendering, but it may take more time compared to using the k3d backend.
 


### PR DESCRIPTION
https://www.notion.so/qim-dtu/Volume-comparison-with-volumetric-view-1fbbab83b2f980eb9e7ed7b7ddfb14f1?v=90f580f0c6b940599414bd7f3d8b642a

Added k3d argument, that plots three k3d plots of the volumes and the selected difference.

Minor changes to k3d 

I have disabled the 'color range fraction' functionality for k3d plots for now to avoid rerendering the plots all the time. We can re-add that if needed

I have made deprecation warning for the 'constant_opacity' functionality in volumetric. Maybe we should keep a list of deprecated changes so we can remember when we need to change them?

An old change in the mesh function which git does not allow me to change back - maybe we can do that in merge editing before merging.