### PR TITLE
Connected components improvements

### DIFF
--- a/qim3d/segmentation/__init__.py
+++ b/qim3d/segmentation/__init__.py
@@ -1,7 +1,7 @@
 from ._common_segmentation_methods import watershed
-from ._connected_components import get_3d_cc
+from ._connected_components import connected_components
 
 __all__ = [
     'watershed',
-    'get_3d_cc',
+    'connected_components',
 ]

--- a/qim3d/segmentation/_connected_components.py
+++ b/qim3d/segmentation/_connected_components.py
@@ -1,33 +1,80 @@
 import numpy as np
-from scipy.ndimage import find_objects, label
+import matplotlib.pyplot as plt
+from scipy.ndimage import find_objects, label, generate_binary_structure
 
 from qim3d.utils._logger import log
 
+class LabeledVolume:
+    def __init__(self, labels: np.ndarray):
+        self.labels = labels
+        self.shape = labels.shape
+        self._sizes = None
+        self._count = self.labels.max()
+    
+    @property
+    def sizes(self) -> np.ndarray:
+        """Returns the sizes of the labels."""
+        if self._sizes is None:
+            self._sizes = np.bincount(self.labels.ravel())
+        return self._sizes
+    
+    def __len__(self) -> int:
+        """Number of non-background labels"""
+        return self._count
+    
+    def filter_by_size(self, min_size: int = None, max_size: int = None) -> np.ndarray:
+        """
+        Extract a labels volume where only the labels with size within the chosen range are kept.
 
-class CC:
-    def __init__(self, connected_components: np.ndarray, num_connected_components: int):
+        Args:
+            min_size: Lower bound of the range. Default value of None does not set a lower bound.
+            max_size: Upper bound of the range. Default value of None does not set an upper bound.
+        """
+        keep = np.zeros(len(self) + 1, dtype=bool)
+        for i, size in enumerate(self.sizes[1:], start=1):
+            if (min_size is None or size >= min_size) and (max_size is None or size <= max_size):
+                keep[i] = True
+        mapping = np.arange(len(keep))
+        mapping[~keep] = 0
+        return mapping[self.labels]
+
+    def filter_by_largest(self, n: int = 1) -> np.ndarray:
+        """Extract a labels volume where only the largest (by size) n labels are kept."""
+        keep = np.zeros(len(self) + 1, dtype=bool)
+        largest_indices = np.argsort(self.sizes[1:])[-n:] + 1
+        keep[largest_indices] = True
+        mapping = np.arange(len(keep))
+        mapping[~keep] = 0
+        return mapping[self.labels]
+
+    def sizes_histogram(self) -> None:
+        """Plot the distribution of the sizes of the labels."""
+        vals = self.sizes[1:]
+        bins = np.logspace(np.log10(vals.min()), np.log10(vals.max()), 50)
+        plt.hist(vals, bins=bins, edgecolor='white', color='orange')
+        plt.xscale('log')
+        plt.xlabel('Size (number of pixels)')
+        plt.ylabel('Frequency')
+        plt.title('Histogram over the label sizes')
+        plt.show()
+
+
+class ConnectedComponents(LabeledVolume):
+    def __init__(self, vol: np.ndarray, connectivity: int = 1):
         """
         Initializes a ConnectedComponents object.
 
         Args:
-            connected_components (np.ndarray): The connected components.
-            num_connected_components (int): The number of connected components.
+            vol (np.ndarray): Volume to compute connected components on.
+            connectivity (int, optional): Controls the squared distance of connectivity. Can range from 1 to 3.
 
         """
-        self._connected_components = connected_components
-        self.cc_count = num_connected_components
-
-        self.shape = connected_components.shape
-
-    def __len__(self):
-        """
-        Returns the number of connected components in the object.
-        """
-        return self.cc_count
+        labels, count = label(vol, structure=generate_binary_structure(rank=3, connectivity=connectivity))
+        super().__init__(labels)
 
     def get_cc(self, index: int | None = None, crop: bool = False) -> np.ndarray:
         """
-        Get the connected component with the given index, if index is None selects a random component.
+        Get the connected component with the given index, if index is None selects all components.
 
         Args:
             index (int): The index of the connected component.
@@ -40,15 +87,15 @@ class CC:
 
         """
         if index is None:
-            volume = self._connected_components
+            volume = self.labels
         elif index == 'random':
-            index = np.random.randint(1, self.cc_count + 1)
-            volume = self._connected_components == index
+            index = np.random.randint(1, len(self) + 1)
+            volume = self.labels == index
         else:
             assert (
-                1 <= index <= self.cc_count
+                1 <= index <= len(self)
             ), 'Index out of range. Needs to be in range [1, cc_count].'
-            volume = self._connected_components == index
+            volume = self.labels == index
 
         if crop:
             # As we index get_bounding_box element 0 will be the bounding box for the connected component at index
@@ -70,31 +117,65 @@ class CC:
         """
 
         if index:
-            assert 1 <= index <= self.cc_count, 'Index out of range.'
-            return find_objects(self._connected_components == index)
+            assert 1 <= index <= len(self), 'Index out of range.'
+            return find_objects((self.labels == index).astype(int))
         else:
-            return find_objects(self._connected_components)
+            return find_objects(self.labels)
 
-
-def get_3d_cc(image: np.ndarray) -> CC:
+def connected_components(volume: np.ndarray, connectivity: int = 1) -> ConnectedComponents:
     """
-    Returns an object (CC) containing the connected components of the input volume. Use plot_cc to visualize the connected components.
+    Computes connected components of a binary volume.
 
     Args:
-        image (np.ndarray): An array-like object to be labeled. Any non-zero values in `input` are
+        volume (np.ndarray): An array-like object to be labeled. Any non-zero values in `input` are
             counted as features and zero values are considered the background.
+        connectivity (int, optional): Controls the squared distance of connectivity. Can range from 1 to 3.
 
     Returns:
-        CC: A ConnectedComponents object containing the connected components and the number of connected components.
+        cc: A ConnectedComponents object containing the labeled volume and a number of useful methods and attributes.
 
     Example:
         ```python
         import qim3d
-        vol = qim3d.examples.cement_128x128x128[50:150]<60
-        cc = qim3d.segmentation.get_3d_cc(vol)
+
+        vol = qim3d.examples.cement_128x128x128
+        binary = qim3d.filters.gaussian(vol, sigma=2) < 60
+        cc = qim3d.segmentation.connected_components(binary)
+        color_map = qim3d.viz.colormaps.segmentation(len(cc), style='bright')
+        qim3d.viz.slicer(cc.labels, slice_axis=1, color_map=color_map)
+        ```
+    
+    Example: Show the largest connected components
+        ```python
+        import qim3d
+
+        vol = qim3d.examples.cement_128x128x128
+        binary = qim3d.filters.gaussian(vol, sigma=2) < 60
+        cc = qim3d.segmentation.connected_components(binary)
+        filtered = cc.filter_by_largest(5)
+
+        color_map = qim3d.viz.colormaps.segmentation(len(cc), style='bright')
+        qim3d.viz.volumetric(filtered, color_map=color_map, constant_opacity=True)
+        ```
+    
+    Example: Filter the connected components by size
+        ```python
+        import qim3d
+
+        vol = qim3d.examples.cement_128x128x128
+        binary = qim3d.filters.gaussian(vol, sigma=2) < 60
+        cc = qim3d.segmentation.connected_components(binary)
+        
+        # Show a histogram of the distribution of label sizes
+        cc.sizes_histogram()
+
+        # Based on the histogram, choose a range of sizes
+        filtered = cc.filter_by_size(min_size=1e2, max_size=2e2)
+
+        color_map = qim3d.viz.colormaps.segmentation(len(cc), style='bright')
+        qim3d.viz.volumetric(filtered, color_map=color_map, constant_opacity=True)
         ```
 
     """
-    connected_components, num_connected_components = label(image)
-    log.info(f'Total number of connected components found: {num_connected_components}')
-    return CC(connected_components, num_connected_components)
+    cc = ConnectedComponents(volume, connectivity)
+    return cc

--- a/qim3d/viz/__init__.py
+++ b/qim3d/viz/__init__.py
@@ -1,7 +1,7 @@
 """Visualization of volumetric data."""
 
 from . import _layers2d, colormaps
-from ._cc import plot_cc
+from ._connected_components import plot_connected_components
 from ._data_exploration import (
     chunks,
     compare_volumes,
@@ -28,7 +28,7 @@ from .itk_vtk_viewer import itk_vtk
 __all__ = [
     '_layers2d',
     'colormaps',
-    'plot_cc',
+    'plot_connected_components',
     'chunks',
     'compare_volumes',
     'fade_mask',

--- a/qim3d/viz/_connected_components.py
+++ b/qim3d/viz/_connected_components.py
@@ -2,12 +2,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import qim3d
-from qim3d.segmentation._connected_components import CC
+from qim3d.segmentation._connected_components import ConnectedComponents
 from qim3d.utils._logger import log
 
 
-def plot_cc(
-    connected_components: CC,
+def plot_connected_components(
+    connected_components: ConnectedComponents,
     component_indexs: list | tuple = None,
     max_cc_to_plot: int = 32,
     overlay: np.ndarray = None,

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -157,7 +157,7 @@ def slices_grid(
         type(color_map) == matplotlib.colors.LinearSegmentedColormap
         or color_map == 'segmentation'
     ):
-        num_labels = len(np.unique(volume))
+        num_labels = volume.max()
 
         if color_map == 'segmentation':
             color_map = qim3d.viz.colormaps.segmentation(num_labels)


### PR DESCRIPTION
**Summary of Changes**

- Added methods for filtering by largest components and by a specified range. Addresses issue #68.
- Fixed bug in `get_bounding_box`.
- Abstracted ConnectedComponents to have a super class called LabeledVolume, which enables reuse of functionality for other labeling methods than connected components such as the watershed algorithm.
- Fixed bug in `viz.slices_grid` where the segmentation color map would not work as intended if some of the labels were not present in the labeled volume, which was the case when using the new filtering methods.
- Added documentation examples that illustrate the use of the class and the new methods.