### PR TITLE
new export for ome zarr files

### DIFF
--- a/qim3d/io/_ome_zarr.py
+++ b/qim3d/io/_ome_zarr.py
@@ -199,7 +199,7 @@ def export_ome_zarr(
     downsample_rate: int = 2,
     order: int = 1,
     replace: bool = False,
-    method: str = 'scaleZYX',
+    method: str = 'scaleZYXdask_coarsen',
     progress_bar: bool = True,
     progress_bar_repeat_time: str = 'auto',
 ) -> None:
@@ -215,7 +215,7 @@ def export_ome_zarr(
         downsample_rate (int, optional): The factor by which to downsample the data for each scale. Must be greater than 1. Defaults to 2.
         order (int, optional): The interpolation order to use when downsampling. Defaults to 1 (linear). Use 0 for a faster nearest-neighbor interpolation.
         replace (bool, optional): Whether to replace the existing directory if it already exists. Defaults to False.
-        method (str, optional): The method used for downsampling. If set to "dask", Dask arrays are used for chunking and downsampling. Defaults to "scaleZYX".
+        method (str, optional): The method used for downsampling. If set to "dask", Dask arrays are used for chunking and downsampling. Defaults to "scaleZYXdask_coarsen".
         progress_bar (bool, optional): Whether to display a progress bar during export. Defaults to True.
         progress_bar_repeat_time (str or int, optional): The repeat interval (in seconds) for updating the progress bar. Defaults to "auto".
 


### PR DESCRIPTION
 using dask coarsen with np.mean
 method call: method='scaleZYXdask_coarsen'
 
 initial version, could add way to specify reduction method for dask.coarsen, if needed