### PR TITLE
fix: resolve NameError in viz.threshold caused by undefined slice_axis

### DIFF
--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -1711,7 +1711,7 @@ def threshold(
 
     # Visualization function
     def update_visualization() -> None:
-        slice_img = np.take(volume, state['position'], axis = slice_axis)
+        slice_img = volume[state['position'], :, :]
         with output:
             output.clear_output(wait=True)  # Clear previous plot
             fig, axes = plt.subplots(1, 4, figsize=(25, 5))


### PR DESCRIPTION
Fixes #99 

`update_visualization()` referenced slice_axis which was never defined in scope. 

Fixed to match existing behaviour in `update_state()` which already hardcodes axis 0.