### PR TITLE
Improve slicer for dask

### DIFF
--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -458,6 +458,13 @@ def slicer(
         ```
         ![viz slicer](../../assets/screenshots/viz-slicer.gif)
     """
+    is_dask = isinstance(volume, da.Array)
+    continuous_update = not is_dask
+
+    if is_dask and mask is not None:
+        raise NotImplementedError(
+            "The mask parameter is not currently supported for Dask-backed volumes."
+        )
 
     if image_size:
         image_height = image_size
@@ -471,23 +478,47 @@ def slicer(
         )
         raise ValueError(msg)
     show_colorbar = colorbar is not None
-    if colorbar == 'slices':
+    if colorbar == 'slices' and not is_dask:
         # Precompute the minimum and maximum along each slice for faster widget sliding.
         non_slice_axes = tuple(i for i in range(volume.ndim) if i != slice_axis)
         slice_mins = np.min(volume, axis=non_slice_axes)
         slice_maxs = np.max(volume, axis=non_slice_axes)
+    elif colorbar == 'volume':
+        get_min = lambda: volume.min().compute() if is_dask else np.min(volume)
+        get_max = lambda: volume.max().compute() if is_dask else np.max(volume)
+
+        if min_value is None and max_value is None and is_dask:
+            vol_min, vol_max = da.compute(volume.min(), volume.max())
+        else:
+            vol_min = get_min() if min_value is None else min_value
+            vol_max = get_max() if max_value is None else max_value
 
     # Create the interactive widget
     def _slicer(slice_positions: int) -> Figure:
-        if colorbar == 'slices':
+        if colorbar == 'slices' and not is_dask:
             dynamic_min = slice_mins[slice_positions]
             dynamic_max = slice_maxs[slice_positions]
+        elif colorbar == 'volume':
+            dynamic_min = vol_min
+            dynamic_max = vol_max
         else:
             dynamic_min = min_value
             dynamic_max = max_value
 
+        if is_dask:
+            slicer_index = [slice(None)] * volume.ndim
+            slicer_index[slice_axis] = slice_positions
+
+            volume_input = volume[tuple(slicer_index)].compute()
+            volume_input = np.expand_dims(volume_input, axis=slice_axis)
+
+            slice_positions_input = 0
+        else:
+            volume_input = volume
+            slice_positions_input = slice_positions
+        
         fig = slices_grid(
-            volume,
+            volume_input,
             slice_axis=slice_axis,
             colormap=colormap,
             min_value=dynamic_min,
@@ -496,7 +527,7 @@ def slicer(
             image_width=image_width,
             display_positions=display_positions,
             interpolation=interpolation,
-            slice_positions=slice_positions,
+            slice_positions=slice_positions_input,
             n_slices=1,
             display_figure=True,
             colorbar=show_colorbar,
@@ -511,7 +542,7 @@ def slicer(
         default_position = int(default_position * (volume.shape[slice_axis] - 1))
     if isinstance(default_position, int):
         if default_position < 0:
-            default_position = volume.shape[slice_axis] - default_position
+            default_position = volume.shape[slice_axis] + default_position
         default_position = np.clip(
             default_position, a_min=0, a_max=volume.shape[slice_axis] - 1
         )
@@ -523,7 +554,7 @@ def slicer(
         min=0,
         max=volume.shape[slice_axis] - 1,
         description='Slice',
-        continuous_update=True,
+        continuous_update=continuous_update,
     )
     slicer_obj = widgets.interactive(_slicer, slice_positions=position_slider)
     slicer_obj.layout = widgets.Layout(align_items='flex-start')

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -413,14 +413,18 @@ def slicer(
 
     * **Scrollable Interface:** Automatically generates a slider for the chosen axis.
     * **Overlay Support:** Visualize segmentation results on top of raw data using the `mask` parameter.
+        Masks are currently not supported for Dask-backed volumes.
     * **Dynamic Contrast:** Use `colorbar='slices'` to adapt intensity ranges per slice, or `'volume'` for a global fixed range.
+    * **Dask Support:** For Dask arrays, only the selected slice is computed during interaction.
 
     Args:
-        volume (numpy.ndarray): The 3D input data to be sliced.
+        volume (numpy.ndarray or dask.array.Array): The 3D input data to be sliced.
         slice_axis (int, optional): The axis to slice along (e.g., 0 for Z, 1 for Y, 2 for X).
         colormap (str or matplotlib.colors.LinearSegmentedColormap, optional): Matplotlib colormap name for the volume.
         min_value (float, optional): Minimum value for color scaling. If `None`, inferred from data.
+            When `colorbar='volume'`, this overrides the global volume minimum.
         max_value (float, optional): Maximum value for color scaling. If `None`, inferred from data.
+            When `colorbar='volume'`, this overrides the global volume maximum.
         image_height (int, optional): Height of the displayed figure.
         image_width (int, optional): Width of the displayed figure.
         display_positions (bool, optional): If `True`, displays the slice index/position on the image.
@@ -433,12 +437,13 @@ def slicer(
             * `None`: No color bar is displayed.
 
         mask (numpy.ndarray, optional): A 3D segmentation mask to overlay on the volume.
+            Masks are currently not supported when `volume` is a Dask array.
         mask_alpha (float, optional): Opacity of the mask overlay (0.0 to 1.0).
         mask_colormap (str, optional): Matplotlib colormap name for the mask.
         default_position (float or int, optional): Initial slice position of the slider.
 
             * **float**: Relative position between 0.0 and 1.0 (e.g., `0.5` starts at the center).
-            * **int**: Exact slice index.
+            * **int**: Exact slice index. Negative values follow standard Python indexing.
 
         **matplotlib_imshow_kwargs: Additional keyword arguments passed to `matplotlib.pyplot.imshow`.
 


### PR DESCRIPTION
## Description
This PR improves `qim3d.viz.slicer` behavior for Dask-backed volumes, specifically aimed at when data is stored chunked on disk, such as Zarr.

Before, `qim3d.viz.slicer` was extremely slow for Dask volumes to the point of being unusuable for any larger volumes stored on disk.

This was due to `slicer` passing the *whole* `volume` to `slices_grid`, which in turn called `volume.compute()` for *every* slider interaction. Thus, the full volume had to be read in from disk on every slice, which is in opposition to lazy loading.

For NumPy arrays, it should work the same as before.

## Changes
- For Dask arrays, only call `.compute()` on the slice and pass this into `slices_grid` instead of the whole volume. This however currently makes it incompatible to pass a Dask array along with `mask`, so a `NotImplementedError` is raised with `mask` different from `None`.
- For Dask arrays, disable continuous updates on the slider such that no computations are done while dragging and only when releasing.
- Make the `colorbar` parameter compatible with Dask arrays.
- Fix bug with parameter `default_position` when passing a negative integer.
- If `colorbar='volume'`, then passing `min_value` or `max_value` overrides the global min/max. Before, they would be ignored.