### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
-﻿# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
-repos:
+﻿repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     -   id: detect-private-key
     -   id: check-docstring-first
@@ -11,7 +9,7 @@ repos:
     -   id: name-tests-test
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.15.20
     hooks:
       # Run the formatter and fix code styling
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,40 @@
 ﻿repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: detect-private-key
-    -   id: check-docstring-first
-    -   id: debug-statements
-    -   id: double-quote-string-fixer
-    -   id: name-tests-test
+      # Security
+      - id: detect-private-key
 
--   repo: https://github.com/astral-sh/ruff-pre-commit
+      # Nit
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+      # Windows
+      - id: check-illegal-windows-names
+      - id: check-case-conflict
+
+      # Data formats
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+
+      # Python
+      - id: debug-statements
+      - id: name-tests-test
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+      - id: pyupgrade
+        args: ["--py311-plus"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:
-      # Run the formatter and fix code styling
-    - id: ruff-format
+      # Run the linter and fix what is possible
+      - id: ruff-check
+        args: ["--fix"]
 
-    # Run the linter and fix what is possible
-    - id: ruff
-      args: ['--fix']
+      # Run the formatter and fix code styling
+      - id: ruff-format

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pre-commit>=4.1.0
-ruff>=0.9.3
+ruff>=0.15.20
 testbook>=0.4.2
 mkdocs>=1.6.1
 mkdocs-material>=9.6.7


### PR DESCRIPTION
Updates the pre-commit hooks which were fairly ancient at this stage.

Additionally it adds a few more hooks that seem useful and aren't overly opinionated.

The original pre-commit person seems to be Anna Ekner, but she is no longer with the project, so I am not sure who the best person for this PR would be.