### PR TITLE
refactor(pyproject): reorder and clean up pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,18 @@
-[build-system]
-requires = ["setuptools>=61.2"]
-build-backend = "setuptools.build_meta"
 
 [project]
 name = "qim3d"
 version = "1.5.3"
-authors = [{ name = "Felipe Delestro", email = "fima@dtu.dk" }]
+license = "MIT"
 description = "QIM tools and user interfaces for volumetric imaging"
+urls = { Homepage = "https://platform.qim.dk/qim3d" }
+authors = [
+    { name = "Felipe Delestro", email = "fima@dtu.dk" },
+    { name = "QIM Development Team", email = "info@qim.dk" },
+]
+maintainers = [
+    { name = "Felipe Delestro", email = "fima@dtu.dk" },
+    { name = "QIM Development Team", email = "info@qim.dk" },
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 5 - Production/Stable",
@@ -18,47 +24,62 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: User Interfaces",
 ]
-urls = { Homepage = "https://platform.qim.dk/qim3d" }
+
 requires-python = ">=3.11"
 dependencies = [
-    "pytetwild",
-    "h5py>=3.9.0",
-    "localthickness>=0.1.2",
-    "matplotlib>=3.8.0",
-    "pydicom==2.4.4",
+    # Base
+    "dask>=2023.6.0",
     "numpy>=1.26.0",
-    "outputformat>=0.1.3",
+    "scipy>=1.11.2",
+
+    # Mesh
+    "trimesh>=4.4.9",
+    "pytetwild",
+
+    # Viz
+    "imageio-ffmpeg>=0.6",
+    "k3d>=2.17",
+    "matplotlib>=3.8.0",
     "Pillow>=10.0.1",
     "plotly>=5.14.1",
-    "scipy>=1.11.2",
-    "seaborn>=0.12.2",
-    "tifffile>=2025.1.10",
-    "imagecodecs>=2024.12.30",
-    "tqdm>=4.65.0",
-    "nibabel>=5.2.0",
-    "ipywidgets>=8.1.2",
-    "dask>=2023.6.0",
-    "k3d>=2.17",
-    "olefile>=0.46",
-    "psutil>=5.9.0",
-    "structure-tensor>=0.2.1",
-    "zarr>=3.0",
-    "ome_zarr>=0.12.0",
-    "dask-image>=2024.5.3",
-    "scikit-image>=0.24.0",
-    "trimesh>=4.4.9",
     "PyGEL3D>=0.6.1",
-    "slgbuilder>=0.2.1",
     "pyvista[jupyter]>=0.45",
-    "imageio-ffmpeg>=0.6",
+    "seaborn>=0.12.2",
+    "tqdm>=4.65.0",
+
+    # Jupyter
+    "ipywidgets>=8.1.2",
+
+    # Data
+    "h5py>=3.9.0",
+    "imagecodecs>=2024.12.30",
+    "nibabel>=5.2.0",
     "numcodecs<0.16",
-    "pygorpho>=1.0.1"
+    "olefile>=0.46",
+    "ome_zarr>=0.12.0",
+    "pydicom==2.4.4",
+    "tifffile>=2025.1.10",
+    "zarr>=3.0",
+
+    # Processing
+    "dask-image>=2024.5.3",
+    "localthickness>=0.1.2",
+    "pygorpho>=1.0.1",
+    "scikit-image>=0.24.0",
+    "slgbuilder>=0.2.1",
+    "structure-tensor>=0.2.1",
+
+    # Miscellaneous
+    "outputformat>=0.1.3",
+    "psutil>=5.9.0",
 ]
-license = "MIT"
 
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
+
+[project.scripts]
+qim3d = "qim3d.cli:main"
 
 [project.optional-dependencies]
 deep-learning = [
@@ -68,9 +89,7 @@ deep-learning = [
     "monai>=1.2.0",
 ]
 
-synthetic-data = [
-    "noise>=1.2.2",
-]
+synthetic-data = ["noise>=1.2.2"]
 
 gui = [
     "gradio>=5.1,<6",
@@ -80,21 +99,38 @@ gui = [
 ]
 
 all = [
-    "gradio>=5.1,<6",
-    "gradio-improvedfileexplorer>=1.0.0",
-    "fastapi>=0.109.0",
-    "uvicorn[standard]>=0.27.0",
-    "torch>=2.0.1",
-    "torchvision>=0.15.2",
-    "torchinfo>=1.8.0",
-    "monai>=1.2.0",
-    "noise>=1.2.2",
+    "qim3d[deep-learning]",
+    "qim3d[synthetic-data]",
+    "qim3d[gui]",
 ]
 
+[dependency-groups]
+dev = [
+    { include-group = "docs" },
+    { include-group = "jupyter" },
+    { include-group = "lint" },
+    { include-group = "test" },
+]
 
-[project.scripts]
-qim3d = "qim3d.cli:main"
+docs = [
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.6.7",
+    "mkdocstrings[python]>=0.28.2",
+    "mktestdocs>=0.2.4",
+]
 
+jupyter = [
+    # See: https://github.com/microsoft/vscode-jupyter/issues/17228#issuecomment-4477302475 and a plethora of other issues on vscode-jupyter.
+    "ipykernel<7",
+]
+
+lint = [
+    "ruff>=0.15.20"  # Should match version in .pre-commit-config.yaml
+]
+
+test = ["pytest>=9.1.1"]
+
+### Tools
 [tool.setuptools]
 include-package-data = true
 license-files = []
@@ -102,16 +138,11 @@ license-files = []
 [tool.setuptools.packages]
 find = { namespaces = false }
 
-
 # See list of rules here: https://docs.astral.sh/ruff/rules/
-
 [tool.ruff]
 line-length = 88
 indent-width = 4
-exclude = [
-    "docs", 
-    "qim3d/tests", 
-]
+exclude = ["docs", "qim3d/tests"]
 
 [tool.ruff.lint]
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -159,10 +190,16 @@ select = [
 ]
 
 ignore = [
-    "F821",
-    "F841",
-    "E501",
-    "E731",
+    "ANN002",
+    "ANN003",
+    "ANN101",
+    "ANN201",
+    "ANN204",
+    "B008",
+    "B026",
+    "B028",
+    "B905",
+    "COM812",
     "D100",
     "D101",
     "D107",
@@ -173,13 +210,13 @@ ignore = [
     "D211",
     "D212",
     "D401",
-    "D406", 
+    "D406",
     "D407",
-    "ANN002",
-    "ANN003",
-    "ANN101",
-    "ANN201",
-    "ANN204",
+    "E501",
+    "E731",
+    "F821",
+    "F841",
+    "ISC001",
     "S101",
     "S301",
     "S311",
@@ -187,15 +224,9 @@ ignore = [
     "S603",
     "S605",
     "S607",
-    "B008",
-    "B026",
-    "B028",
-    "B905",
+    "SIM113",
     "W291",
     "W293",
-    "COM812",
-    "ISC001",
-    "SIM113",
 ]
 
 [tool.ruff.format]
@@ -208,10 +239,15 @@ omit = [
     "qim3d/examples/*",
     "qim3d/css/*",
     "docs/*",
-    "**/__init__.py", 
+    "**/__init__.py",
     "config.py",
     "config-3.py",
 ]
 
 [tool.pytest.ini_options]
-addopts = "-p no:warnings"       # "--ignore=qim3d/tests/notebooks -p no:warnings"
+addopts = "-p no:warnings" # "--ignore=qim3d/tests/notebooks -p no:warnings"
+
+### Build System
+[build-system]
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is a general cleanup and reordering of the proproject.toml file and does not contain any substantial changes.

- Adds "QIM Development Team" as a contributor
- Adds `maintainers` field
- Reorders some elements of [project] table
- Moves [build-system] to end of file
- Adds commented sections to [dependencies]
- Improves qim[all] optional dependency setup by referring to other groups
- Adds the dev dependencies as dependency groups
- Alphabetically orders the [tool.ruff].ignore array

While these changes are somewhat nitty and annoying to review, I would argue that cleaning up the pyproject.toml file is worthwhile.

This also paves the way for some of the upcoming changes I have in mind.