### PR TITLE
fix: import error trips up test runner

### DIFF
--- a/qim3d/tests/segmentation/test_segmentation.py
+++ b/qim3d/tests/segmentation/test_segmentation.py
@@ -2,26 +2,26 @@ import numpy as np
 import pytest
 
 import qim3d
-from qim3d.segmentation._connected_components import get_3d_cc
+from qim3d.segmentation._connected_components import connected_components
 
 
-# Unit tests for get_3d_cc()
+# Unit tests for connected_components()
 @pytest.fixture(scope='module')
 def setup_data():
     components = np.array(
         [[0, 0, 1, 1, 0, 0], [0, 0, 0, 1, 0, 0], [1, 1, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0]]
     )
     num_components = 4
-    connected_components = get_3d_cc(components)
-    return connected_components, components, num_components
+    connected_components_ = connected_components(components)
+    return connected_components_, components, num_components
 
 
 def test_connected_components_property(setup_data):
-    connected_components, _, _ = setup_data
+    connected_components_, _, _ = setup_data
     components = np.array(
         [[0, 0, 1, 1, 0, 0], [0, 0, 0, 1, 0, 0], [2, 2, 0, 0, 3, 0], [0, 0, 0, 4, 0, 0]]
     )
-    assert np.array_equal(connected_components.get_cc(), components)
+    assert np.array_equal(connected_components_.get_cc(), components)
 
 
 def test_num_connected_components_property(setup_data):


### PR DESCRIPTION
This problem appears to have been introduced in 30de1d056a77b8e105539aa2409ee3584fc27a41.

Strangely, this suggests that the full test suite has not been run at least since October last year? See #115

Note that this does not fix the tests in `test_segmentation.py`, 5/6 of which are stilling failing after this, but simply fixes the import error which prevents `pytest` from running.

Note also: this does not pass pre-commit, but the offending hooks did not pass previously either.