### PR TITLE
fix: dev deps for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,11 @@ lint = [
     "ruff>=0.15.20"  # Should match version in .pre-commit-config.yaml
 ]
 
-test = ["pytest>=9.1.1"]
+test = [
+    "pytest>=9.1.1",
+    "testbook>=0.4.2",
+    "pytest-cov>=7.1.0",
+]
 
 ### Tools
 [tool.setuptools]


### PR DESCRIPTION
These were missed in #123.

Note that this changes from `coverage` to `pytest-cov`, which I believe is a preferable route. This is a pytest plugin that integrates `coverage` into `pytest`.

I believe neither are actually used anywhere at the moment, but I have included `pytest-cov` here as I expect it will come up in future testing work anyway.