### PR TITLE
ci: tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,18 @@ You may wish to install pre-commit as a tool to be able to run it outside the gi
 uv tool install pre-commit
 ```
 
+### Task runner: `just`
+
+For ease of development, this project uses the popular [`just`](https://just.systems/) task runner, which is configured via the [`justfile`](/justfile) in the root of the repository.
+
+You can install it with:
+
+```sh
+uv tool install rust-just
+```
+
+When installed, you can easily perform common tasks with just. To see an overview of available commands, simply run `just` in the terminal.
+
 ## Git
 
 The sections below describe some of the best practices of `git` that we strive to abide by.
@@ -42,6 +54,7 @@ In summary, they are:
 4. PRs must get:
    1. Technical review by a QIM Developer
    2. Final review by a Senior QIM Team Member (Jakob: @jakobsj or Felipe: @delestro)
+
 ### Crash Course
 
 If you have the required permissions to create branches on the `qim3d` repository, you can put the branches for PR's there. If you don't, you can use the GitHub _fork_ feature to create a fork of the `qim3d` repository under your own user account and make pull requests and associated branches there.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+set minimum-version := '1.55.0'
+set default-list := true
+
+# Installs the project dependencies
+[group: 'dev']
+install:
+    uv sync --all-extras
+
+# Formats the code using ruff
+[group: 'format']
+format:
+    uv run ruff check . --fix
+    uv run ruff format .
+
+# Checks the code for linting errors
+[group: 'format']
+lint:
+    uv run ruff check .
+
+# Runs the test suite
+[group: 'test']
+test:
+    uv run pytest
+
+# Serves documentation locally
+[group: 'docs']
+docs-serve:
+    uv run mkdocs serve
+
+[group: 'docs']
+docs-build:
+    uv run mkdocs build


### PR DESCRIPTION
This adds a very simple CI over our test suite using `pytest`. Note that this presupposes that the oldest supported Python version is 3.12, as per SPEC-0 which was adopted yesterday.

Further down the line we would want to improve this with:
- Better reporting
- Coverage reporting
- Parallelised tests

Though these efforts are beyond the scope of this PR and are tracked in #154.

Note that there are still many issues related to the test suite at the moment, these can however be fixed after this has been merged, though we will need to look at some ugly ❌ icons for a bit. Perhaps we consider this an incentive to fix the tests!

Non-critically blocked by:
- #155 
- #115 

Fixes: #116 
