### PR TITLE
ci: pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,15 @@
+name: Pre-Commit Checks
+on: [pull_request]
+
+# Note: we use prek (https://github.com/j178/prek) instead of pre-commit
+# prek is fully compatible, faster, and generally a better experience than pre-commit.
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Pre-Commit
+        uses: j178/prek-action@v2


### PR DESCRIPTION
This adds a pre-commit CI using `prek`.

Note that until #118 is merged none of the CI runs will pass. This is okay and we can safely merge this before without having fixed #118 first.

Related:
- #118 
- #112