### PR TITLE
fix: correct filter wrapper args and update docstrings

### DIFF
--- a/qim3d/features/_common_features_methods.py
+++ b/qim3d/features/_common_features_methods.py
@@ -7,30 +7,30 @@ from qim3d.utils._logger import log
 
 
 def prepare_obj(
-    obj: np.ndarray | hmesh.Manifold,
+    obj: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
     mesh_precision: float = 1.0,
     return_mesh: bool = True,
-) -> np.ndarray | hmesh.Manifold:
+) -> np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh:
     """
     Prepares a volume or mesh for feature extraction by applying thresholding and masking (if specified).
     Optionally returns a mesh or a binarized volume.
 
     Args:
-        obj (np.ndarray or hmesh.Manifold): Input `np.ndarray` volume or a mesh object of type `pygel3d.hmesh.Manifold`.
+        obj (np.ndarray, hmesh.Manifold, or SurfaceMesh): Input `np.ndarray` volume or a mesh object.
         threshold (float, str, or None): Threshold value, ignored if input is a mesh or volume is already binary. Defaults to 'otsu' for Otsu's method.
         mask (np.ndarray or None): Boolean mask to apply for a region of interest in the volume. Must match the shape of the input volume. Ignored if input is a mesh.
         mesh_precision (float): Precision parameter for mesh generation.
         return_mesh (bool): If True, returns a mesh. Otherwise, returns the binarized and/or masked volume.
 
     Returns:
-        hmesh.Manifold or np.ndarray: Mesh or binarized/masked volume, depending on `return_mesh`.
+        hmesh.Manifold, SurfaceMesh, or np.ndarray: Mesh or binarized/masked volume, depending on `return_mesh`.
 
     """
 
     # If already a mesh, return as is
-    if isinstance(obj, hmesh.Manifold):
+    if isinstance(obj, (hmesh.Manifold, qim3d.mesh.SurfaceMesh)):
         return obj
 
     volume = np.asarray(obj)
@@ -71,7 +71,7 @@ def prepare_obj(
 
 
 def volume(
-    object: np.ndarray | hmesh.Manifold,
+    object: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
 ) -> float:
@@ -81,7 +81,7 @@ def volume(
     This function quantifies the amount of space occupied by a structure. It is robust and versatile, handling both raw 3D image arrays (voxels) and pre-generated meshes. If a voxel array is provided, it is automatically converted into a mesh using the specified threshold before the volume is calculated, ensuring sub-voxel accuracy compared to simple voxel counting.
 
     Args:
-        object (np.ndarray or hmesh.Manifold): The input data. Can be a 3D NumPy array (volume) or a `pygel3d.hmesh.Manifold` object (mesh).
+        object (np.ndarray, hmesh.Manifold, or SurfaceMesh): The input data. Can be a 3D NumPy array (volume), a `pygel3d.hmesh.Manifold` object, or a `qim3d.mesh.SurfaceMesh` object.
         mask (np.ndarray, optional): A boolean mask defining a Region of Interest (ROI). Only the volume within this mask is included. Must have the same shape as `object`. Defaults to `None`.
         threshold (float or str, optional): The intensity value used to binarize the volume if a NumPy array is provided.
 
@@ -112,31 +112,35 @@ def volume(
         print(volume)
         ```
         48774.99
+
     """
     # Prepare object
     mesh = prepare_obj(object, threshold=threshold, mask=mask, return_mesh=True)
 
     # Compute volume
-    volume = hmesh.volume(mesh)
+    if isinstance(mesh, hmesh.Manifold):
+        volume = hmesh.volume(mesh)
+    else:
+        volume = mesh.volume
 
     return volume
 
 
 def area(
-    object: np.ndarray | hmesh.Manifold,
+    object: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
 ) -> float:
     """
     Calculates the total surface area of a 3D object.
 
-    This function quantifies the surface size of a structure, which is a fundamental metric in morphometry and material science. It accepts either a raw 3D volume (which is automatically meshed using Marching Cubes) or a pre-computed `PyGEL3D` mesh.
+    This function quantifies the surface size of a structure, which is a fundamental metric in morphometry and material science. It accepts either a raw 3D volume (which is automatically meshed using Marching Cubes) or a pre-computed mesh (`pygel3d.hmesh.Manifold` or `qim3d.mesh.SurfaceMesh`).
 
     Args:
-        object (np.ndarray or hmesh.Manifold): The input data. Can be a 3D NumPy array (volume) or a `pygel3d.hmesh.Manifold` object (mesh).
+        object (np.ndarray, hmesh.Manifold, or SurfaceMesh): The input data. Can be a 3D NumPy array (volume), a `pygel3d.hmesh.Manifold` object, or a `qim3d.mesh.SurfaceMesh` object.
         mask (np.ndarray, optional): A boolean mask defining a Region of Interest (ROI) within the volume. Must have the same shape as `object`. Defaults to `None`.
         threshold (float or str, optional): The intensity value used to binarize the volume if a NumPy array is provided.
-            
+
             * **float**: A specific intensity value.
             * **'otsu'**: Automatically calculates the threshold using Otsu's method. Defaults to 'otsu'.
 
@@ -162,7 +166,7 @@ def area(
         58535.06
 
     Example:
-        Compute area from a `pygel3d.hmesh.Manifold` mesh:
+        Compute area from a mesh:
         ```python
         import qim3d
 
@@ -177,18 +181,22 @@ def area(
         print(area)
         ```
         58535.06
+
     """
     # Prepare object
     mesh = prepare_obj(object, threshold=threshold, mask=mask, return_mesh=True)
 
     # Compute area
-    area = hmesh.area(mesh)
+    if isinstance(mesh, hmesh.Manifold):
+        area = hmesh.area(mesh)
+    else:
+        area = mesh.area
 
     return area
 
 
 def sphericity(
-    object: np.ndarray | hmesh.Manifold,
+    object: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
 ) -> float:
@@ -201,7 +209,7 @@ def sphericity(
     * **< 1.0**: Indicates irregular, elongated, or rough shapes (e.g., a cube has a sphericity of approx. 0.806).
 
     Args:
-        object (np.ndarray or hmesh.Manifold): The input data. Can be a 3D NumPy array (volume) or a `pygel3d.hmesh.Manifold` object (mesh).
+        object (np.ndarray, hmesh.Manifold, or SurfaceMesh): The input data. Can be a 3D NumPy array (volume), a `pygel3d.hmesh.Manifold` object, or a `qim3d.mesh.SurfaceMesh` object.
         mask (np.ndarray, optional): A boolean mask defining a Region of Interest (ROI). Only the data within this mask is considered. Must have the same shape as `object`. Defaults to `None`.
         threshold (float or str, optional): The intensity value used to binarize the volume if a NumPy array is provided.
 
@@ -252,6 +260,7 @@ def sphericity(
         ```
         Sphericity: 0.6876
         <iframe src="https://platform.qim.dk/k3d/sphericity_feature_example_1.html" width="100%" height="500" frameborder="0"></iframe>
+
     """
     # Prepare object
     mesh = prepare_obj(object, threshold=threshold, mask=mask, return_mesh=True)
@@ -311,9 +320,10 @@ def mean_std_intensity(
         # Visualize slices of the object
         qim3d.viz.slices_grid(shell_object, color_bar=True, color_bar_style="large")
         ```
-        Mean intensity: 114.6734  
+        Mean intensity: 114.6734
         Standard deviation of intensity: 45.8481
         ![mean_std_intensity_feature](../../assets/screenshots/mean_std_intensity_feature_example.png)
+
     """
 
     # Mask the volume (if provided)
@@ -330,7 +340,7 @@ def mean_std_intensity(
 
 
 def size(
-    object: np.ndarray | hmesh.Manifold,
+    object: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
 ) -> float:
@@ -340,7 +350,7 @@ def size(
     This function determines the largest spatial extent of the object along the Cartesian axes (X, Y, Z). It computes the Axis-Aligned Bounding Box (AABB) enclosing the structure and returns the length of its longest side. This metric is useful for characterizing the overall scale, fitting constraints, or the maximum caliper diameter along orthogonal axes.
 
     Args:
-        object (np.ndarray or hmesh.Manifold): The input data. Can be a 3D NumPy array (volume) or a `pygel3d.hmesh.Manifold` object (mesh).
+        object (np.ndarray, hmesh.Manifold, or SurfaceMesh): The input data. Can be a 3D NumPy array (volume), a `pygel3d.hmesh.Manifold` object, or a `qim3d.mesh.SurfaceMesh` object.
         mask (np.ndarray, optional): A boolean mask defining a Region of Interest (ROI). Only the data within this mask is considered. Must have the same shape as `object`. Defaults to `None`.
         threshold (float or str, optional): The intensity value used to binarize the volume if a NumPy array is provided.
 
@@ -374,23 +384,34 @@ def size(
         ```
         Size: 100.0
         <iframe src="https://platform.qim.dk/k3d/size_feature_example.html" width="100%" height="500" frameborder="0"></iframe>
+
     """
     # Prepare object
     mesh = prepare_obj(object, threshold=threshold, mask=mask, return_mesh=True)
 
     # Min and max corners of the bounding box
-    bbox = hmesh.bbox(mesh)
-    mins, maxs = bbox
+    if isinstance(mesh, hmesh.Manifold):
+        bbox = hmesh.bbox(mesh)
+        mins, maxs = bbox
+        side_lengths = maxs - mins
+    else:
+        bounds = mesh.bounds  # (xmin, xmax, ymin, ymax, zmin, zmax)
+        side_lengths = np.array(
+            [
+                bounds[1] - bounds[0],
+                bounds[3] - bounds[2],
+                bounds[5] - bounds[4],
+            ]
+        )
 
     # Maximum side length of the bounding box
-    side_lengths = maxs - mins
     size = np.max(side_lengths)
 
     return size
 
 
 def roughness(
-    object: np.ndarray | hmesh.Manifold,
+    object: np.ndarray | hmesh.Manifold | qim3d.mesh.SurfaceMesh,
     mask: np.ndarray | None = None,
     threshold: float | str = 'otsu',
 ) -> float:
@@ -400,7 +421,8 @@ def roughness(
     This feature quantifies the morphological complexity of an object. Unlike a simple measure of size, this ratio indicates how "folded", "spiky", or "porous" a structure is relative to its mass. A perfect sphere has the lowest possible surface-to-volume ratio (smoothest), while highly complex shapes like fractals, trabecular bone, or dendrites will have a much higher value. This metric is often used to analyze texture and surface irregularity.
 
     Args:
-        object (np.ndarray or hmesh.Manifold): The input data. Can be a 3D NumPy array (volume) or a `pygel3d.hmesh.Manifold` object (mesh).
+        object (np.ndarray, hmesh.Manifold, or SurfaceMesh): The input data. Can be a 3D NumPy array (volume), a `pygel3d.hmesh.Manifold` object, or a `qim3d.mesh.SurfaceMesh` object.
+
         mask (np.ndarray, optional): A boolean mask defining a Region of Interest (ROI). Only the data within this mask is considered. Must have the same shape as `object`. Defaults to `None`.
         threshold (float or str, optional): The intensity value used to binarize the volume if a NumPy array is provided.
 
@@ -455,6 +477,7 @@ def roughness(
         ```
         Roughness: 0.2534
         <iframe src="https://platform.qim.dk/k3d/roughness_feature_example_v2.html" width="100%" height="500" frameborder="0"></iframe>
+
     """
     # Prepare object
     mesh = prepare_obj(object, threshold=threshold, mask=mask, return_mesh=True)

--- a/qim3d/filters/_common_filter_methods.py
+++ b/qim3d/filters/_common_filter_methods.py
@@ -1,8 +1,8 @@
 """Provides filter functions and classes for image processing"""
 
-from typing import Type, Callable
 import abc
 import inspect
+from collections.abc import Callable
 
 import dask.array as da
 import dask_image.ndfilters as dask_ndfilters
@@ -12,8 +12,16 @@ from skimage import morphology
 
 from qim3d.utils import log
 
+
 class FilterBase:
-    def __init__(self, *args, dask: bool = False, chunks: str = 'auto',save_output:bool = False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        dask: bool = False,
+        chunks: str = 'auto',
+        save_output: bool = False,
+        **kwargs,
+    ):
         """
         Base class for image filters.
 
@@ -29,24 +37,27 @@ class FilterBase:
         self.save_output = save_output
 
     @abc.abstractmethod
-    def __call__(self, input:np.ndarray) -> np.ndarray:
+    def __call__(self, input: np.ndarray) -> np.ndarray:
         pass
 
+
 class Filter(FilterBase):
-    def __init__(self, func:Callable, *args, **kwargs):
+    def __init__(self, func: Callable, *args, **kwargs):
         self.func = func
         super().__init__(*args, **kwargs)
 
     def __call__(self, input):
         return self.func(input, *self.args, **self.kwargs)
 
+
 class Threshold(FilterBase):
-    def __init__(self, threshold:int|float, *args, **kwargs):
+    def __init__(self, threshold: float, *args, **kwargs):
         self.threshold = threshold
         super().__init__(*args, **kwargs)
 
-    def __call__(self, input:np.ndarray):
+    def __call__(self, input: np.ndarray):
         return input > self.threshold
+
 
 class Gaussian(FilterBase):
     def __init__(self, sigma: float, *args, **kwargs):
@@ -82,6 +93,7 @@ class Gaussian(FilterBase):
             **self.kwargs,
         )
 
+
 class Sobel(FilterBase):
     def __init__(self, *args, **kwargs):
         """
@@ -94,7 +106,7 @@ class Sobel(FilterBase):
         """
         super().__init__(*args, **kwargs)
 
-    def __call__(self, input:np.ndarray) -> np.ndarray:
+    def __call__(self, input: np.ndarray) -> np.ndarray:
         """
         Applies a Sobel filter to the input.
 
@@ -106,6 +118,7 @@ class Sobel(FilterBase):
 
         """
         return sobel(input, self.dask)
+
 
 class Median(FilterBase):
     def __init__(
@@ -139,7 +152,7 @@ class Median(FilterBase):
 
         """
         return median(
-            vol=input,
+            volume=input,
             size=self.size,
             footprint=self.footprint,
             dask=self.dask,
@@ -180,7 +193,7 @@ class Maximum(FilterBase):
 
         """
         return maximum(
-            vol=input,
+            volume=input,
             size=self.size,
             footprint=self.footprint,
             dask=self.dask,
@@ -221,7 +234,7 @@ class Minimum(FilterBase):
 
         """
         return minimum(
-            vol=input,
+            volume=input,
             size=self.size,
             footprint=self.footprint,
             dask=self.dask,
@@ -243,9 +256,10 @@ class Tophat(FilterBase):
 
         """
         return tophat(input, dask=self.dask, **self.kwargs)
-    
+
+
 class Normalize(FilterBase):
-    def __call__(self, input:np.ndarray) -> np.ndarray:
+    def __call__(self, input: np.ndarray) -> np.ndarray:
         return normalize(input)
 
 
@@ -253,7 +267,7 @@ class Pipeline:
     """
     Orchestrates a sequential chain of image processing operations.
 
-    This class allows you to build a reproducible workflow (or pipeline) by stacking multiple filters or functions together. 
+    This class allows you to build a reproducible workflow (or pipeline) by stacking multiple filters or functions together.
 
     The output of one step becomes the input to the next. It supports standard Python callables (functions, lambdas) and `qim3d.filters.Filter` objects. It is particularly useful for automating preprocessing routines, such as applying denoising, followed by thresholding, and finally morphological operations.
 
@@ -266,9 +280,9 @@ class Pipeline:
     Example:
         ```python
         import qim3d
-        from qim3d.filters import Pipeline, Filter, Sobel, Threshold 
+        from qim3d.filters import Pipeline, Filter, Sobel, Threshold
         from scipy import ndimage
-        
+
         # Get data
         vol = qim3d.examples.bone_128x128x128.astype('int64')
 
@@ -296,9 +310,10 @@ class Pipeline:
         ![original volume](../../assets/screenshots/pipeline_original.png)
         ![original volume](../../assets/screenshots/pipeline_middlestep.png)
         ![filtered volume](../../assets/screenshots/pipeline_processed.png)
+
     """
 
-    def __init__(self, *args: Type[FilterBase]):
+    def __init__(self, *args: type[FilterBase]):
         """
         Represents a sequence of image filters.
 
@@ -312,9 +327,9 @@ class Pipeline:
         for fn in args:
             self._add_filter(fn)
 
-    def _add_filter(self, fn: Type[FilterBase]|Callable):
+    def _add_filter(self, fn: type[FilterBase] | Callable):
         """
-        Adds a filter to the sequence. 
+        Adds a filter to the sequence.
 
         Args:
             name: A string representing the name or identifier of the filter.
@@ -326,13 +341,17 @@ class Pipeline:
         """
         if not isinstance(fn, FilterBase):
             if not callable(fn):
-                raise TypeError(f'Pipeline only accepts callable objects. Your object is of type "{type(fn)}".')
+                raise TypeError(
+                    f'Pipeline only accepts callable objects. Your object is of type "{type(fn)}".'
+                )
             signature = inspect.signature(fn)
             if signature.parameters != 1:
-                raise TypeError(f'Pipeline only accepts callables that take one argument. Yours takes {signature.parameters}.')
+                raise TypeError(
+                    f'Pipeline only accepts callables that take one argument. Yours takes {signature.parameters}.'
+                )
         self.filters.append(fn)
 
-    def append(self, fn: FilterBase|Callable):
+    def append(self, fn: FilterBase | Callable):
         """
         Adds a new processing step to the end of the pipeline.
 
@@ -352,10 +371,11 @@ class Pipeline:
             # Append a second filter to the pipeline
             pipeline.append(Median(size=5))
             ```
+
         """
         self._add_filter(fn)
 
-    def __call__(self, input:np.ndarray):
+    def __call__(self, input: np.ndarray):
         """
         Applies the sequential filters to the input in order.
 
@@ -373,8 +393,10 @@ class Pipeline:
                 self.saved_outputs.append(input)
         return input
 
-def normalize(vol:np.ndarray) -> np.ndarray:
-    return 255 * int((vol - vol.min())/vol.max())
+
+def normalize(vol: np.ndarray) -> np.ndarray:
+    return 255 * int((vol - vol.min()) / vol.max())
+
 
 def gaussian(
     volume: np.ndarray, sigma: float, dask: bool = False, chunks: str = 'auto', **kwargs
@@ -409,6 +431,7 @@ def gaussian(
         ```
         ![gaussian-filter-before](../../assets/screenshots/gaussian_filter_original.png)
         ![gaussian-filter-after](../../assets/screenshots/gaussian_filter_processed.png)
+
     """
 
     if dask:
@@ -420,8 +443,9 @@ def gaussian(
     else:
         res = ndimage.gaussian_filter(volume, sigma, **kwargs)
         return res
-    
-def sobel(vol:np.ndarray, dask:bool = False):
+
+
+def sobel(vol: np.ndarray, dask: bool = False):
     """
     Computes the magnitude of the intensity gradient using the Sobel operator to detect edges.
 
@@ -444,24 +468,24 @@ def sobel(vol:np.ndarray, dask:bool = False):
         # Cast to int64 to prevent overflow during gradient calculation
         vol = qim3d.examples.bone_128x128x128.astype('int64')
         filtered_vol = qim3d.filters.sobel(vol)
-        
+
         qim3d.viz.slices_grid(vol, num_slices=5)
         qim3d.viz.slices_grid(filtered_vol, num_slices=5)
         ```
         ![sobel-filter-before](../../assets/screenshots/sobel_filter_original.png)
         ![sobel-filter-after](../../assets/screenshots/pipeline_middlestep.png)
+
     """
     if dask:
         if not isinstance(vol, da.Array):
             vol = da.from_array()
-    sob0 = ndimage.sobel(vol,0)
-    sob1 = ndimage.sobel(vol,1)
+    sob0 = ndimage.sobel(vol, 0)
+    sob1 = ndimage.sobel(vol, 1)
     if vol.ndim == 3:
-        sob2 = ndimage.sobel(vol,2)
+        sob2 = ndimage.sobel(vol, 2)
         return np.sqrt(sob0**2 + sob1**2 + sob2**2)
     else:
         return np.sqrt(sob0**2 + sob1**2)
-
 
 
 def median(
@@ -509,6 +533,7 @@ def median(
         ```
         ![median-filter-before](../../assets/screenshots/median_filter_original.png)
         ![median-filter-after](../../assets/screenshots/median_filter_processed.png)
+
     """
     if size is None:
         if footprint is None:
@@ -566,6 +591,7 @@ def maximum(
         ```
         ![maximum-filter-before](../../assets/screenshots/maximum_filter_original.png)
         ![maximum-filter-after](../../assets/screenshots/maximum_filter_processed.png)
+
     """
     if size is None:
         if footprint is None:
@@ -622,6 +648,7 @@ def minimum(
         ```
         ![minimum-filter-before](../../assets/screenshots/minimum_filter_original.png)
         ![minimum-filter-after](../../assets/screenshots/minimum_filter_processed.png)
+
     """
     if size is None:
         if footprint is None:
@@ -672,6 +699,7 @@ def tophat(volume: np.ndarray, dask: bool = False, **kwargs):
         ```
         ![tophat-filter-before](../../assets/screenshots/tophat_filter_original.png)
         ![tophat-filter-after](../../assets/screenshots/tophat_filter_processed.png)
+
     """
 
     radius = kwargs['radius'] if 'radius' in kwargs else 3

--- a/qim3d/generate/_generators.py
+++ b/qim3d/generate/_generators.py
@@ -6,7 +6,7 @@ import scipy.ndimage
 from IPython.display import display
 
 import qim3d
-from qim3d.utils import log
+from qim3d.utils import log, scale_to_float16
 from qim3d.utils._dependencies import optional_import
 
 # Import noise as optional dependency
@@ -16,6 +16,7 @@ pnoise3 = noise.pnoise3
 snoise3 = noise.snoise3
 
 __all__ = ['volume', 'background']
+
 
 def background(
     background_shape: tuple,
@@ -31,7 +32,7 @@ def background(
     """
     Generates a 3D noise field or adds synthetic background noise to an existing volume.
 
-    Unlike `volume` (which creates structures), this function generates **unstructured uniform noise**. 
+    Unlike `volume` (which creates structures), this function generates **unstructured uniform noise**.
     It is useful for simulating:
 
     * **Sensor Noise:** Electronic noise or grain common in CT/microscopy scans.
@@ -39,30 +40,30 @@ def background(
     * **Data Augmentation:** Making training data more robust by adding random interference.
 
     Args:
-        background_shape (tuple): 
+        background_shape (tuple):
             The shape of the noise volume to generate (Z, Y, X).
-        baseline_value (float, optional): 
+        baseline_value (float, optional):
             The constant base intensity level of the background.
-        min_noise_value (float, optional): 
+        min_noise_value (float, optional):
             The lower bound of the random noise distribution.
-        max_noise_value (float, optional): 
+        max_noise_value (float, optional):
             The upper bound of the random noise distribution.
-        generate_method (str, optional): 
+        generate_method (str, optional):
             How to combine the baseline with the noise: `'add'`, `'subtract'`, `'multiply'`, or `'divide'`.
-        apply_method (str, optional): 
+        apply_method (str, optional):
             If `apply_to` is provided, this defines how the noise is merged with the input volume.
-        seed (int, optional): 
+        seed (int, optional):
             Random seed for reproducibility.
-        dtype (str, optional): 
+        dtype (str, optional):
             Output data type.
-        apply_to (numpy.ndarray, optional): 
-            An existing 3D volume. If provided, the noise is applied directly to this array 
+        apply_to (numpy.ndarray, optional):
+            An existing 3D volume. If provided, the noise is applied directly to this array
             using `apply_method`.
 
     Returns:
-        background (numpy.ndarray): 
+        background (numpy.ndarray):
             The noise volume (if `apply_to` is None) or the modified input volume.
-            
+
     Raises:
         ValueError: If `apply_method` is not one of 'add', 'subtract', 'multiply', or 'divide'.
         ValueError: If `apply_method` is provided without `apply_to` input volume provided, or vice versa.
@@ -245,8 +246,8 @@ def volume(
     """
     Generates a synthetic 3D volume using structured Perlin noise.
 
-    Creates valid 3D morphological structures that resemble biological or material samples 
-    (e.g., cells, tissues, pores). By default, it generates a "blob-like" object, but it can 
+    Creates valid 3D morphological structures that resemble biological or material samples
+    (e.g., cells, tissues, pores). By default, it generates a "blob-like" object, but it can
     also create specific geometric shapes like **cylinders** or **tubes**.
 
     This function is ideal for:
@@ -256,51 +257,51 @@ def volume(
     * **Simulation:** Modeling physical structures with controlled noise properties.
 
     **Supported Shapes:**
-    
+
     * **Blob:** (Default) amorphous, organic-looking structure.
     * **Cylinder:** A solid cylindrical rod.
     * **Tube:** A hollow cylinder.
 
     Args:
-        base_shape (tuple, optional): 
-            The resolution of the internal noise grid. Higher values create finer details 
+        base_shape (tuple, optional):
+            The resolution of the internal noise grid. Higher values create finer details
             but require more computation.
-        final_shape (tuple, optional): 
-            The final output resolution. If `None`, matches `base_shape`. 
+        final_shape (tuple, optional):
+            The final output resolution. If `None`, matches `base_shape`.
             Use this to upsample the generated volume.
-        noise_scale (float, optional): 
-            Controls the "zoom" of the noise texture. Smaller values = smooth, large features. 
+        noise_scale (float, optional):
+            Controls the "zoom" of the noise texture. Smaller values = smooth, large features.
             Larger values = rough, high-frequency details.
-        noise_type (str, optional): 
+        noise_type (str, optional):
             The noise algorithm: `perlin` (standard) or `simplex` (faster, different artifacts).
-        decay_rate (float, optional): 
-            Controls how quickly the object fades into the background at the edges. 
+        decay_rate (float, optional):
+            Controls how quickly the object fades into the background at the edges.
             Higher values create sharper, distinct boundaries.
-        gamma (float, optional): 
+        gamma (float, optional):
             Adjusts contrast. `<1` flattens values (fuzzier), `>1` pushes values to extremes (binary-like).
-        threshold (float, optional): 
-            The cut-off value (0.0 to 1.0) defining the object's surface. 
+        threshold (float, optional):
+            The cut-off value (0.0 to 1.0) defining the object's surface.
             Lower values make the object larger/fatter; higher values make it smaller/thinner.
-        max_value (float, optional): 
+        max_value (float, optional):
             The maximum intensity value in the output array (e.g., 255 for 8-bit images).
-        shape (str, optional): 
+        shape (str, optional):
             Forces the volume into a geometric shape: `None` (Blob), `cylinder`, or `tube`.
-        tube_hole_ratio (float, optional): 
-            Only for `tube`. Defines the relative thickness of the wall. 
+        tube_hole_ratio (float, optional):
+            Only for `tube`. Defines the relative thickness of the wall.
             `0.1` is a thick wall, `0.9` is a thin shell.
-        axis (int, optional): 
+        axis (int, optional):
             The orientation axis (0, 1, or 2) for cylinders and tubes.
-        order (int, optional): 
+        order (int, optional):
             Interpolation order when resizing to `final_shape` (0=Nearest, 1=Linear, etc.).
-        dtype (str, optional): 
+        dtype (str, optional):
             Output data type (e.g., `uint8`, `float32`).
-        hollow (int, optional): 
+        hollow (int, optional):
             If > 0, hollows out the blob by eroding the center, creating a shell of thickness `hollow`.
-        seed (int, optional): 
+        seed (int, optional):
             Random seed for reproducibility.
 
     Returns:
-        vol (numpy.ndarray): 
+        vol (numpy.ndarray):
             The generated 3D volume.
 
     Raises:
@@ -536,8 +537,8 @@ class ParameterVisualizer:
     """
     Interactive Jupyter widget for exploring synthetic data generation parameters.
 
-    Provides a Graphical User Interface (GUI) to tune the parameters of `qim3d.generate.volume` 
-    in real-time. Users can adjust sliders for noise scale, threshold, and gamma while immediately 
+    Provides a Graphical User Interface (GUI) to tune the parameters of `qim3d.generate.volume`
+    in real-time. Users can adjust sliders for noise scale, threshold, and gamma while immediately
     seeing the resulting 3D structure.
 
     Args:
@@ -546,14 +547,14 @@ class ParameterVisualizer:
         seed (int, optional): Determines the seed for the volume generation. Enables the user to generate different volumes with the same parameters.
         hollow (int, optional): Determines thickness of the hollowing operation. Volume is only hollowed if hollow>0.
         initial_config (dict, optional): Dictionary that defines the starting parameters of the visualizer. Can be used if a specific setup is needed. The dictionary may contain the keywords: `noise_type`, `noise_scale`, `decay_rate`, `gamma`, `threshold`, `shape` and `tube_hole_ratio`.
-        nsmin (float, optional): Determines minimum value for the noise scale slider. 
+        nsmin (float, optional): Determines minimum value for the noise scale slider.
         nsmax (float, optional): Determines maximum value for the noise scale slider.
-        dsmin (float, optional): Determines minimum value for the decay rate slider. 
-        dsmax (float, optional): Determines maximum value for the decay rate slider. 
-        gsmin (float, optional): Determines minimum value for the gamma slider. 
-        gsmax (float, optional): Determines maximum value for the gamma slider. 
-        tsmin (float, optional): Determines minimum value for the threshold slider. 
-        tsmax (float, optional): Determines maximum value for the threshold slider. 
+        dsmin (float, optional): Determines minimum value for the decay rate slider.
+        dsmax (float, optional): Determines maximum value for the decay rate slider.
+        gsmin (float, optional): Determines minimum value for the gamma slider.
+        gsmax (float, optional): Determines maximum value for the gamma slider.
+        tsmin (float, optional): Determines minimum value for the threshold slider.
+        tsmax (float, optional): Determines maximum value for the threshold slider.
         grid_visible (bool, optional): Determines if the grid should be visible upon plot generation.
 
     Raises:
@@ -1009,7 +1010,7 @@ class ParameterVisualizer:
         """
         Extracts the generated volume from the widget's current state.
 
-        Allows you to retrieve the numpy array resulting from your interactive adjustments 
+        Allows you to retrieve the numpy array resulting from your interactive adjustments
         so you can use it in your pipeline (e.g., saving it or using it for training).
 
         Returns:
@@ -1021,5 +1022,6 @@ class ParameterVisualizer:
             my_custom_blob = viz.get_volume()
             qim3d.io.save("custom_blob.tif", my_custom_blob)
             ```
+
         """
         return self.plt_volume.volume


### PR DESCRIPTION
This PR fixes argument passing errors in filter wrappers that caused crashes with `SurfaceMesh` objects, modernizes filter type annotations, and cleans up docstrings and missing imports across core generator and feature modules.
---
### Changes
#### Filter Wrapper Corrections (`_common_filter_methods.py`)
* Fixed argument names when calling `median`, `maximum`, and `minimum` from within their class wrappers (`vol=input` → `volume=input`).
* Modernized type annotations (e.g., `type[FilterBase] | Callable`).
* **Closes:** #143
#### Generators & Features (`_generators.py`, `_common_features_methods.py`)
* Cleaned up and formatted docstrings to conform to project standards.
* Added missing imports (`scale_to_float16`) in `_generators.py`.
* **Closes:** #144
