### PR TITLE
fix(viz): replace deprecated Matplotlib colormap API

### DIFF
--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -3340,7 +3340,7 @@ class OverlaySlicer:
 
         if isinstance(cmaps, str | matplotlib.colors.Colormap):
             cmaps = (cmaps, cmaps)
-        self.cmaps = tuple(matplotlib.cm.get_cmap(c) for c in cmaps)
+        self.cmaps = tuple(matplotlib.colormaps.get_cmap(c) for c in cmaps)
         self.img_format = 'png'
 
         self.slice_axis = 0


### PR DESCRIPTION
`matplotlib.cm.get_cmap` was [deprecated](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm) in Matplotlib 3.7. Since `pyproject.toml` requires `matplotlib>=3.8.0`, this causes `OverlaySlicer` to raise an error during initialization, preventing the `overlay` visualization from working.