### PR TITLE
chore(dev): add notebook dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ docs = [
 jupyter = [
     # See: https://github.com/microsoft/vscode-jupyter/issues/17228#issuecomment-4477302475 and a plethora of other issues on vscode-jupyter.
     "ipykernel<7",
+    "notebook>=7.6.1",
 ]
 
 lint = [


### PR DESCRIPTION
## Summary

Add `notebook` to the `jupyter` dependency group in `pyproject.toml`.

## Description

Running:

```bash
uv run jupyter notebook
````

currently fails with:

```
ModuleNotFoundError: No module named 'notebook'
```

The command can be made to work by installing the package temporarily:

```bash
uv run --with notebook jupyter notebook
```

However, including `notebook` in the `jupyter` dependency group avoids having to do this and also ensures it is available when activating the project's virtual environment directly.