### PR TITLE
chore: bump `PyGEL3d` to ensure broken release not targeted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "matplotlib>=3.8.0",
     "Pillow>=10.0.1",
     "plotly>=5.14.1",
-    "PyGEL3D>=0.6.1",
+    "PyGEL3D==0.6.1",  # Pin until resolved: https://github.com/janba/GEL/issues/148
     "pyvista[jupyter]>=0.45",
     "seaborn>=0.12.2",
     "tqdm>=4.65.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "matplotlib>=3.8.0",
     "Pillow>=10.0.1",
     "plotly>=5.14.1",
-    "PyGEL3D==0.6.1",  # Pin until resolved: https://github.com/janba/GEL/issues/148
+    "PyGEL3D==0.7.3",
     "pyvista[jupyter]>=0.45",
     "seaborn>=0.12.2",
     "tqdm>=4.65.0",


### PR DESCRIPTION
Note: This does not touch `requirements.txt` as I do not want to do duplicate work, see pending #130.

Fixes #162 