### PR TITLE
fix: avoid stale volumetric doctest output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ site/
 .pytest_cache/
 .ruff_cache/
 *.coverage
-*.html
 
 # Notebooks
 .ipynb_checkpoints/

--- a/qim3d/viz/_k3d.py
+++ b/qim3d/viz/_k3d.py
@@ -10,9 +10,9 @@ Volumetric visualization using K3D.
 import k3d
 import matplotlib.pyplot as plt
 import numpy as np
-import pygel3d
 import plotly.graph_objects as go
 from matplotlib.colors import Colormap
+from pygel3d import hmesh
 
 from qim3d.utils._decorators import coarseness
 from qim3d.utils._logger import log
@@ -24,7 +24,7 @@ def volumetric(
     volume: np.ndarray,
     aspectmode: str = 'data',
     show: bool = True,
-    save: bool = False,
+    save: bool | str = False,
     grid_visible: bool = False,
     colormap: str = 'magma',
     constant_opacity: bool = False,
@@ -102,11 +102,17 @@ def volumetric(
         qim3d.viz.volumetric(vol)
         ```
         <iframe src="https://platform.qim.dk/k3d/fima-bone_128x128x128-20240221113459.html" width="100%" height="500" frameborder="0"></iframe>
-        
+
         Save the rendering to an HTML file without displaying it:
         ```python
-        plot = qim3d.viz.volumetric(vol, show=False, save="my_render.html")
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "my_render.html"
+            plot = qim3d.viz.volumetric(vol, show=False, save=str(output_path))
         ```
+
     """
 
     pixel_count = volume.shape[0] * volume.shape[1] * volume.shape[2]
@@ -126,11 +132,11 @@ def volumetric(
     if aspectmode.lower() not in ['data', 'cube']:
         msg = "aspectmode should be either 'data' or 'cube'"
         raise ValueError(msg)
-    
+
     if camera_mode not in ['orbit', 'trackball', 'fly']:
         msg = "camera_mode should be either 'orbit', 'trackbal' or 'fly'"
         raise ValueError(msg)
-    
+
     # check if image should be downsampled for visualization
     original_shape = volume.shape
     volume = downscale_img(volume, max_voxels=max_voxels)
@@ -216,7 +222,7 @@ def volumetric(
 
 
 def mesh(
-    mesh,
+    mesh: hmesh.Manifold,
     backend: str = 'pygel3d',
     wireframe: bool = True,
     flat_shading: bool = True,
@@ -261,7 +267,7 @@ def mesh(
     Returns:
         plot (k3d.Plot or go.FigureWidget or None):
             The visualization object.
-            
+
             * **k3d.Plot**: Returned if `backend='k3d'` and `show=False`.
             * **go.FigureWidget**: Returned if `backend='pygel3d'`.
             * **None**: Returned if `backend='k3d'` and `show=True`.
@@ -289,6 +295,7 @@ def mesh(
         qim3d.viz.mesh(mesh, backend='k3d', wireframe=False, flat_shading=False)
         ```
         ![k3d_visualization](../../assets/screenshots/viz-k3d_mesh.png)
+
     """
 
     if len(mesh.vertices()) > 100000:


### PR DESCRIPTION
Fixes #174

## Summary
- run the HTML-saving docstring example inside a temporary directory so the executable documentation cleans up after itself
- stop globally ignoring HTML files, making accidental generated output visible
- correct the `save` union type and use the existing PyGEL manifold type for the adjacent mesh argument

## Testing
- `uv run --no-sync pytest qim3d/tests/docstrings/test_docstrings.py::test_docstrings_viz -k volumetric -q` (1 passed, 28 deselected)
- `uv run --no-sync ruff check qim3d/viz/_k3d.py`
- `uv run --no-sync ruff format --check qim3d/viz/_k3d.py`
- verified `my_render.html` does not exist after the docstring test