### PR TITLE
refactor(test): better docstring mocking

### DIFF
--- a/qim3d/_types.py
+++ b/qim3d/_types.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+import matplotlib
+
+PathLike = Path | str
+ColormapLike = str | matplotlib.colors.Colormap

--- a/qim3d/tests/docstrings/test_docstrings.py
+++ b/qim3d/tests/docstrings/test_docstrings.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 import matplotlib
 from unittest.mock import patch, MagicMock
@@ -9,8 +11,54 @@ matplotlib.use('Agg')
 # Get dictionary of functions by module
 functions_by_module = get_all_functions_by_module()
 
+def noop_mock():
+    return MagicMock()
+
+# Per-(module, function) mocks to apply while a docstring's code blocks execute.
+# Each target maps a dotted import path to a callable that should return a mock object.
+# Note that the target depends on how it is imported in the module.
+# (see viz -> export_rotation below as example)
+MOCK_TARGETS: dict[str, dict[str, dict[str, Callable[[], object]]]] = {
+    "viz": {
+        "chunks": {
+            "qim3d.viz.chunks": noop_mock,
+        },
+        "export_rotation": {
+            "imageio.v2.mimsave": noop_mock,
+            "imageio.v2.get_writer": noop_mock,
+            "qim3d.viz._data_exploration.Image": noop_mock,
+            "qim3d.viz._data_exploration.display": noop_mock,
+        },
+        "mesh": {
+            "pyvista.Plotter": noop_mock,
+        },
+    },
+    "mesh": {
+        "from_volume": {
+            "pyvista.Plotter": noop_mock,
+        },
+    },
+}
+
+@pytest.fixture(autouse=True)
+def _apply_mock_targets(request):
+    # request.node.originalname is the test function name without the
+    # parametrize id suffix, e.g. "test_docstrings_processing".
+    module_name = request.node.originalname.removeprefix("test_docstrings_")
+    func = request.node.callspec.params.get("func")
+    targets = MOCK_TARGETS.get(module_name, {}).get(func.__name__, {})
+
+    patches = [patch(path, new=factory()) for path, factory in targets.items()]
+    for p in patches:
+        p.start()
+
+    yield
+
+    for p in patches:
+        p.stop()
+
 # Mock the qim3d.io.Downloader class and its methods
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_downloader():
     with patch("qim3d.io.Downloader") as MockDownloader:
 
@@ -25,7 +73,6 @@ def mock_downloader():
 # Mock the qim3d.io load and save functions
 @pytest.fixture
 def mock_io_functions():
-
     # List of functions to mock
     functions_to_mock = [
         "qim3d.io.load",
@@ -36,8 +83,7 @@ def mock_io_functions():
 
     patches = []
     for func_path in functions_to_mock:
-
-        # Mock the function to return a fake dataset 
+        # Mock the function to return a fake dataset
         patcher = patch(func_path, return_value=MagicMock(name=f"Mocked_{func_path.split('.')[-1]}"))
         patches.append(patcher)
         patcher.start()
@@ -52,7 +98,6 @@ def mock_io_functions():
 # Mock the qim3d.io OME-Zarr functions
 @pytest.fixture
 def mock_ome_zarr_functions(tmp_path):
-    
     # Temporary directory for mock files
     mock_file_path = tmp_path / "Escargot.zarr"
 
@@ -81,15 +126,8 @@ def mock_ome_zarr_functions(tmp_path):
     for patcher in patches:
         patcher.stop()
 
-# Mock the qim3d.viz.chunks function
-@pytest.fixture
-def mock_viz_chunks():
-    with patch("qim3d.viz.chunks") as MockVizChunks:
-        MockVizChunks.return_value = None
-        yield MockVizChunks
-
 @pytest.mark.parametrize('func', functions_by_module["io"], ids=lambda d: d.__name__)
-def test_docstrings_io(func, mock_downloader, mock_io_functions, mock_ome_zarr_functions):
+def test_docstrings_io(func, mock_io_functions, mock_ome_zarr_functions):
     check_docstring(obj=func)
 
 @pytest.mark.parametrize('func', functions_by_module["generate"], ids=lambda d: d.__name__)
@@ -97,7 +135,7 @@ def test_docstrings_generate(func):
     check_docstring(obj=func)
 
 @pytest.mark.parametrize('func', functions_by_module["viz"], ids=lambda d: d.__name__)
-def test_docstrings_viz(func, mock_downloader, mock_ome_zarr_functions, mock_viz_chunks):
+def test_docstrings_viz(func):
     check_docstring(obj=func)
 
 @pytest.mark.parametrize('func', functions_by_module["features"], ids=lambda d: d.__name__)
@@ -122,7 +160,6 @@ def test_docstrings_operations(func):
 
 @pytest.mark.parametrize('func', functions_by_module["processing"], ids=lambda d: d.__name__)
 def test_docstrings_processing(func):
-    
     # Exclude qim3d.processing.segment_layers function, since it uses unavailable example data
     if func.__name__ == "segment_layers":
         return
@@ -134,7 +171,6 @@ def test_docstrings_mesh(func):
 
 @pytest.mark.parametrize('func', functions_by_module["ml"], ids=lambda d: d.__name__)
 def test_docstrings_ml(func):
-
     # Exclude train_model, load_checkpoint, and test_model functions
     if func.__name__ in ["train_model", "load_checkpoint", "test_model"]:
         return

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -40,6 +40,7 @@ from skimage.filters import (
 
 import qim3d
 import qim3d.operations
+from qim3d._types import ColormapLike, PathLike
 from qim3d.utils import log
 from qim3d.utils._decorators import coarseness
 
@@ -48,8 +49,6 @@ try:
     from tqdm.notebook import tqdm
 except ImportError:
     from tqdm import tqdm
-
-ColormapLike = str | matplotlib.colors.Colormap
 
 
 @coarseness('volume')
@@ -2660,13 +2659,13 @@ def _get_save_path(user_input: str, default_dir: str = '.') -> Path:
 
 
 def export_rotation(
-    path: str,
+    path: PathLike,
     volume: np.ndarray,
     degrees: int = 360,
     n_frames: int = 180,
     fps: int = 30,
     image_size: tuple[int, int] | None = (256, 256),
-    colormap: str = 'magma',
+    colormap: ColormapLike = 'magma',
     camera_height: float = 2.0,
     camera_distance: float | str = 'auto',
     camera_focus: list | str = 'center',
@@ -2684,13 +2683,13 @@ def export_rotation(
     * **Customizable Camera:** Control the height, distance, and focus point of the rotation.
 
     Args:
-        path (str): The destination file path. Must end with .gif, .avi, .mp4, or .webm. If no extension is provided, defaults to .gif.
+        path (PathLike): The destination file path. Must end with .gif, .avi, .mp4, or .webm.
         volume (numpy.ndarray): The 3D input volume to be animated.
         degrees (int, optional): Total rotation angle in degrees (e.g., 360 for a full spin).
         n_frames (int, optional): Total number of frames to generate. Higher values create smoother/slower animations at fixed FPS.
         fps (int, optional): Frames per second. Controls the playback speed.
         image_size (tuple[int, int] or None, optional): Resolution (width, height) of the output frames.
-        colormap (str, optional): Matplotlib colormap name for the volume rendering.
+        colormap (ColormapLike, optional): Matplotlib colormap for the volume rendering.
         camera_height (float, optional): Vertical position of the camera relative to the volume's Z-axis height.
         camera_distance (float or str, optional): Distance from the camera to the focus point.
 
@@ -2752,10 +2751,6 @@ def export_rotation(
         msg = f'Value "{camera_distance}" for camera distance is invalid. Use "auto" or a float value.'
         raise TypeError(msg)
 
-    if Path(path).suffix == '':
-        print(f'Input path: "{path}" does not have a filetype. Defaulting to .gif.')
-        path += '.gif'
-
     # Handle img in (xyz) instead of (zyx) (due to rendering issues with the up-vector, ensure that z=y, such that we now have (x,z,y))
     vol = np.transpose(volume, (2, 0, 1))
 
@@ -2807,28 +2802,26 @@ def export_rotation(
         img = plotter.screenshot(return_img=True, window_size=image_size)
         frames.append(img)
 
-    if path[-4:] == '.gif':
-        imageio.mimsave(path, frames, fps=fps, loop=0)
+    path = Path(path)
+    match path.suffix.lower():
+        case '.gif':
+            imageio.mimsave(path, frames, fps=fps, loop=0)
+        case '.avi' | '.mp4':
+            writer = imageio.get_writer(path, fps=fps)
+            for frame in frames:
+                writer.append_data(frame)
+            writer.close()
+        case '.webm':
+            writer = imageio.get_writer(
+                path, fps=fps, codec='vp9', ffmpeg_params=['-crf', '32']
+            )
+            for frame in frames:
+                writer.append_data(frame)
+            writer.close()
+        case _:
+            msg = 'Invalid file extension. Please use .gif, .avi, .mp4 or .webm'
+            raise ValueError(msg)
 
-    elif path[-4:] == '.avi' or path[-4:] == '.mp4':
-        writer = imageio.get_writer(path, fps=fps)
-        for frame in frames:
-            writer.append_data(frame)
-        writer.close()
-
-    elif path[-5:] == '.webm':
-        writer = imageio.get_writer(
-            path, fps=fps, codec='vp9', ffmpeg_params=['-crf', '32']
-        )
-        for frame in frames:
-            writer.append_data(frame)
-        writer.close()
-
-    else:
-        msg = 'Invalid file extension. Please use .gif, .avi, .mp4 or .webm'
-        raise ValueError(msg)
-
-    path = _get_save_path(path)
     log.info('File saved to ' + str(path.resolve()))
 
     if show:


### PR DESCRIPTION
This adds a better way of mocking objects in the docstring tests.

It fixes a few tests, but most importantly it fixes #131, and partially fixes #155.

Fixes #131

---

I guess maybe adding private module `qim3d._types` is controversial, though I reckon it likely is not.

Longer term it would be nice to get more (correct!) type hinting in the library, so I reckon `_types.py` has merit going forward.

There is a lot more clean-up to be done in `test_docstrings.py`, but this is at least a good start and implements a good structure for future changes, which could be carried out as a `Good First Issue`