### PR TITLE
chore: remove redundant pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,15 +20,8 @@
       - id: check-json
 
       # Python
-      - id: debug-statements
       - id: name-tests-test
         args: ["--pytest-test-first"]
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        args: ["--py311-plus"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20


### PR DESCRIPTION
This removes the `pyupgrade` and `debug-statements` hooks which are better handled by `ruff`.

This makes additional progress on #118.

Note that the ruff configuration is not yet finalised or merged, but since these are not complied with anyway at the moment, it is fine to remove these hooks even though ruff is not ready to take over quite yet.