### PR TITLE
docs: list public qim3d.io API exports

### DIFF
--- a/docs/api_reference/io.md
+++ b/docs/api_reference/io.md
@@ -1,3 +1,21 @@
 # Input / Output
 
 ::: qim3d.io
+
+## Public API
+
+::: qim3d.io.load
+
+::: qim3d.io.load_mesh
+
+::: qim3d.io.Downloader
+
+::: qim3d.io.save
+
+::: qim3d.io.save_mesh
+
+::: qim3d.io.convert
+
+::: qim3d.io.export_ome_zarr
+
+::: qim3d.io.import_ome_zarr


### PR DESCRIPTION
## Summary

- List every current public qim3d.io export on the existing API reference page.
- Keep the module-level documentation directive and runtime API unchanged.

Closes #204

## Validation

- Standard-library AST/text check confirms every name in qim3d.io.__all__ has a matching documentation directive.
- git diff --check

## Limitation

I could not run a local MkDocs build: the minimal documentation-only environment could not finish acquiring MkDocs dependencies within bounded network observation. No scientific runtime stack was installed. This PR is therefore opened as Draft for CI/reviewer verification of rendered documentation.