### PR TITLE
fix: bumps pydicom to fix CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "nibabel>=5.2.0",
     "olefile>=0.46",
     "ome_zarr>=0.12.0",
-    "pydicom>=2.4.4",
+    "pydicom>=2.4.5",
     "tifffile>=2025.1.10",
     "zarr>=3.0",
 

--- a/uv.lock
+++ b/uv.lock
@@ -4746,7 +4746,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.1" },
     { name = "plotly", specifier = ">=5.14.1" },
     { name = "psutil", specifier = ">=5.9.0" },
-    { name = "pydicom", specifier = ">=2.4.4" },
+    { name = "pydicom", specifier = ">=2.4.5" },
     { name = "pygel3d", specifier = ">=0.8.2" },
     { name = "pygorpho", specifier = ">=1.0.1" },
     { name = "pytetwild" },


### PR DESCRIPTION
We need to bump pydicom version to ensure fix for CVE-2026-32711 is applied