### PR TITLE
Fix broken asset/cross-reference links across docstrings and docs

### DIFF
--- a/docs/examples/image_analysis.md
+++ b/docs/examples/image_analysis.md
@@ -19,7 +19,7 @@ vol = qim3d.examples.bone_128x128x128
 qim3d.viz.threshold(vol)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/interactive_thresholding.gif" alt="thresholding">
+    <img src="../assets/screenshots/interactive_thresholding.gif" alt="thresholding">
 </div>
 
 
@@ -47,10 +47,10 @@ vol_filtered = pipeline(vol)
 fig2 = qim3d.viz.slices_grid(vol_filtered, num_slices=5, display_figure=True)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/filter_original.png" alt="filter_original">
+    <img src="../assets/screenshots/filter_original.png" alt="filter_original">
 </div>
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/filter_processed.png" alt="filter_processed">
+    <img src="../assets/screenshots/filter_processed.png" alt="filter_processed">
 </div>
 
 ## BLOB detection
@@ -74,10 +74,10 @@ blobs, binary_volume = qim3d.detection.blobs(
 qim3d.viz.circles(blobs, vol, alpha=0.8, color="blue")
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/blob_detection.gif" alt="blob_detection>
+    <img src="../assets/screenshots/blob_detection.gif" alt="blob_detection>
 </div>
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/blob_get_mask.gif" alt="blob_mask">
+    <img src="../assets/screenshots/blob_get_mask.gif" alt="blob_mask">
 </div>
 
 
@@ -92,7 +92,7 @@ bin_vol = qim3d.filters.gaussian(vol, sigma=2) < 60
 fig1 = qim3d.viz.slices_grid(bin_vol, slice_axis=1, display_figure=True)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/operations-watershed_before.png" alt="watershed_before">
+    <img src="../assets/screenshots/operations-watershed_before.png" alt="watershed_before">
 </div>
 
 ```py
@@ -104,5 +104,5 @@ fig2 = qim3d.viz.slices_grid(
 )
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/operations-watershed_after.png" alt="watershed_after">
+    <img src="../assets/screenshots/operations-watershed_after.png" alt="watershed_after">
 </div>

--- a/docs/examples/synthetic_data.md
+++ b/docs/examples/synthetic_data.md
@@ -15,7 +15,7 @@ vol = qim3d.generate.volume(noise_scale=0.03, noise_type="perlin")
 qim3d.viz.slices_grid(vol, n_slices=15)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_data_blob.gif" alt="synthetic_data_blob">
+    <img src="../assets/screenshots/synthetic_data_blob.gif" alt="synthetic_data_blob">
 </div>
 
 The noise scale can be adjusted to change the roughness of the blob. A higher `noise_scale` creates finer, more detailed Perlin noise features:
@@ -29,7 +29,7 @@ rough_blob = qim3d.generate.volume(noise_scale=0.05)
 ```
 
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_data_blobs_noise.png" alt="synthetic_data_blobs_noise_scale">
+    <img src="../assets/screenshots/synthetic_data_blobs_noise.png" alt="synthetic_data_blobs_noise_scale">
 </div>
 
 ## Clusters
@@ -43,7 +43,7 @@ cluster = qim3d.generate.berry(num_drupelets=60, core_radius=20)
 qim3d.viz.slices_grid(cluster, n_slices=15)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_data_berry.gif" alt="synthetic_data_berry">
+    <img src="../assets/screenshots/synthetic_data_berry.gif" alt="synthetic_data_berry">
 </div>
 
 Parameters such as `num_drupelets`, `drupelet_radius`, and `return_labels` can be explored to adjust cluster density or obtain instance labels for segmentation:
@@ -57,7 +57,7 @@ cmap = qim3d.viz.colormaps.segmentation(n_labels=len(labels))
 qim3d.viz.slices_grid(labels, colormap=cmap, n_slices=15)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_cluster_labels.png" alt="synthetic_cluster_labels">
+    <img src="../assets/screenshots/synthetic_cluster_labels.png" alt="synthetic_cluster_labels">
 </div>
 
 ## Fibers
@@ -71,7 +71,7 @@ fiber_bundle = qim3d.generate.rope(num_threads=18, twist_rate=2.0)
 qim3d.viz.slices_grid(fiber_bundle, n_slices=15)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_data_rope.gif" alt="synthetic_data_rope">
+    <img src="../assets/screenshots/synthetic_data_rope.gif" alt="synthetic_data_rope">
 </div>
 
 Parameters such as `num_threads`, `twist_rate`, and `thread_thickness` allow exploring different fiber bundle densities and twist frequencies:
@@ -87,5 +87,5 @@ cmap = qim3d.viz.colormaps.segmentation(n_labels=len(thread_labels))
 qim3d.viz.slices_grid(thread_labels, colormap=cmap, n_slices=15)
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/synthetic_rope_labels.png" alt="synthetic_rope_labels">
+    <img src="../assets/screenshots/synthetic_rope_labels.png" alt="synthetic_rope_labels">
 </div>

--- a/docs/examples/visualization.md
+++ b/docs/examples/visualization.md
@@ -15,7 +15,7 @@ Equidistant slices of the mussel µCT-scan can be viewed. Here 15 slices are cho
 qim3d.viz.slices_grid(volume, num_slices=15, color_map="Blues")
 ```
 <div class="notebook-output-figure">
-  <img src="../../assets/screenshots/mussel_slices_grid.png" alt="mussel_slices">
+  <img src="../assets/screenshots/mussel_slices_grid.png" alt="mussel_slices">
 </div>
 
 One can interactively scroll through the different axes of the volume:
@@ -23,7 +23,7 @@ One can interactively scroll through the different axes of the volume:
 qim3d.viz.slicer_orthogonal(volume, colormap="Blues")
 ```
 <div class="notebook-output-figure">
-    <img src="../../assets/screenshots/mussel_slicer_orthogonal.png" alt="mussel_slicer_orthogonal">
+    <img src="../assets/screenshots/mussel_slicer_orthogonal.png" alt="mussel_slicer_orthogonal">
 </div>
 
 ## Histogram
@@ -34,5 +34,5 @@ qim3d.viz.histogram(volume, bins=100, coarseness=2)
 
 <div class="notebook-output-figure">
     <pre>Subsampled volume has size 12.5% of the original volume.</pre>
-    <img src="../../assets/screenshots/mussel_histogram.png" alt="mussel_histogram">
+    <img src="../assets/screenshots/mussel_histogram.png" alt="mussel_histogram">
 </div>

--- a/docs/user_guide/cli.md
+++ b/docs/user_guide/cli.md
@@ -7,7 +7,7 @@ This offers quick interactions, making it ideal for tasks that require efficienc
     ``` title="Command"
     qim3d gui --data-explorer
     ```
-    ![CLI Data Explorer](../../assets/screenshots/CLI-data_explorer.gif)
+    ![CLI Data Explorer](../assets/screenshots/CLI-data_explorer.gif)
 
 
 ## Graphical User Interfaces
@@ -39,7 +39,7 @@ The command line interface allows you to run graphical user interfaces directly 
 
 !!! Example
 
-    Here's an example of how to open the [Data Explorer](../gui/gui.md#qim3d.gui.data_explorer)
+    Here's an example of how to open the [Data Explorer](gui.md#qim3d.gui.data_explorer)
 
     ``` title="Command"
     qim3d gui --data-explorer
@@ -50,7 +50,7 @@ The command line interface allows you to run graphical user interfaces directly 
 
     In this case, the GUI will be available at `http://127.0.0.1:7860`
 
-    ![Data explorer GUI](../../assets/screenshots/GUI-data_explorer.png)
+    ![Data explorer GUI](../assets/screenshots/GUI-data_explorer.png)
 
 
 !!! Example
@@ -82,7 +82,7 @@ The command line interface allows you to run graphical user interfaces directly 
 
     In this case, the GUI will be available at `http://127.0.0.1:47326/gui/fima/47326/`
 
-    ![Local thickness GUI](../../assets/screenshots/GUI-local_thickness.png)
+    ![Local thickness GUI](../assets/screenshots/GUI-local_thickness.png)
 
 
 
@@ -127,7 +127,7 @@ You can launch volumetric visualizations directly from the command line. By defa
 
     A new tab in the default browser will be open with the visualization:
 
-    ![itk-vtk-viewer](../../assets/screenshots/itk-vtk-viewer.gif)
+    ![itk-vtk-viewer](../assets/screenshots/itk-vtk-viewer.gif)
 
 !!! Example "Example using k3d"
     ``` title="Command"
@@ -152,7 +152,7 @@ You can launch volumetric visualizations directly from the command line. By defa
     ```
     And a new tab will be opened in the default browser with the interactive k3d plot:
 
-    ![CLI k3d](../../assets/screenshots/CLI-k3d.png){ width="512" }
+    ![CLI k3d](../assets/screenshots/CLI-k3d.png){ width="512" }
 
 Or an specific path for destination can be used. We can also choose to not open the browser:
 
@@ -196,32 +196,32 @@ File previewing can also be done directly from the command line interface to pre
     qim3d preview blobs_256x256x256.tif
     ```
 
-    ![CLI k3d](../../assets/preview/default.png){ width="512" }
+    ![CLI k3d](../assets/preview/default.png){ width="512" }
 
 !!! Example
     ``` title="Command"
     qim3d preview blobs_256x256x256.tif --resolution 30
     ```
 
-    ![CLI k3d](../../assets/preview/res30.png){ width="512" }
+    ![CLI k3d](../assets/preview/res30.png){ width="512" }
 
 !!! Example
     ``` title="Command"
     qim3d preview blobs_256x256x256.tif --resolution 50 --axis 1
     ```
 
-    ![CLI k3d](../../assets/preview/axis1.png){ width="512" }
+    ![CLI k3d](../assets/preview/axis1.png){ width="512" }
 
 !!! Example
     ``` title="Command"
     qim3d preview blobs_256x256x256.tif --resolution 50 --axis 2 --slice 0
     ```
 
-    ![CLI k3d](../../assets/preview/relativeIntensity.png){ width="512" }
+    ![CLI k3d](../assets/preview/relativeIntensity.png){ width="512" }
 
 !!! Example
     ``` title="Command"
     qim3d preview qim_logo.png --resolution 40
     ```
 
-    ![CLI k3d](../../assets/preview/qimLogo.png){ width="512" }
+    ![CLI k3d](../assets/preview/qimLogo.png){ width="512" }

--- a/docs/user_guide/gui.md
+++ b/docs/user_guide/gui.md
@@ -16,22 +16,22 @@ The `qim3d` library provides a set of custom made GUIs that ease the interaction
     ```
 
 In general, the GUIs can be launched directly from the command line.
-For details see [here](../cli/cli.md#qim3d-gui).
+For details see [here](cli.md#qim3d-gui).
 
 ::: qim3d.gui.data_explorer
     options:
         members: False
-![Data explorer GUI](../../assets/screenshots/GUI-data_explorer.png)
+![Data explorer GUI](../assets/screenshots/GUI-data_explorer.png)
 
 ::: qim3d.gui.local_thickness
     options:
         members: False
-![Local thickness GUI](../../assets/screenshots/GUI-local_thickness.png)
+![Local thickness GUI](../assets/screenshots/GUI-local_thickness.png)
 
 ::: qim3d.gui.iso3d
     options:
         members: False
-![Iso3d GUI](../../assets/screenshots/GUI-iso3d.png)
+![Iso3d GUI](../assets/screenshots/GUI-iso3d.png)
 
 ::: qim3d.gui.annotation_tool
     options:

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -146,7 +146,7 @@ Some Windows users could face an build error during installation.
 This issue occurs because the system lacks the necessary tools to compile the library requirements. To resolve this, follow these steps:
 
 - Go to the [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) page and click on "Download build tools."
-- Run the installer and ensure that `Desktop development with C++` is checked. ![Windows build tools](assets/screenshots/Troubleshooting-Windows_build_tools.png)
+- Run the installer and ensure that `Desktop development with C++` is checked. ![Windows build tools](../assets/screenshots/Troubleshooting-Windows_build_tools.png)
 - Restart your computer
 - Activate your conda enviroment and run `pip install qim3d` again
 

--- a/qim3d/detection/_common_detection_methods.py
+++ b/qim3d/detection/_common_detection_methods.py
@@ -65,13 +65,13 @@ def blobs(
             # Visualize detected blobs
             qim3d.viz.circles(blobs, vol, alpha=0.8, color='blue')
             ```
-            ![blob detection](../../assets/screenshots/blob_detection.gif)
+            ![blob detection](../assets/screenshots/blob_detection.gif)
 
             ```python
             # Visualize binary binary_volume
             qim3d.viz.slicer(binary_volume)
             ```
-            ![blob detection](../../assets/screenshots/blob_get_mask.gif)
+            ![blob detection](../assets/screenshots/blob_get_mask.gif)
     """
     from skimage.feature import blob_dog
 

--- a/qim3d/features/_common_features_methods.py
+++ b/qim3d/features/_common_features_methods.py
@@ -322,7 +322,7 @@ def mean_std_intensity(
         ```
         Mean intensity: 114.6734
         Standard deviation of intensity: 45.8481
-        ![mean_std_intensity_feature](../../assets/screenshots/mean_std_intensity_feature_example.png)
+        ![mean_std_intensity_feature](../assets/screenshots/mean_std_intensity_feature_example.png)
 
     """
 

--- a/qim3d/filters/_common_filter_methods.py
+++ b/qim3d/filters/_common_filter_methods.py
@@ -307,9 +307,9 @@ class Pipeline:
         # Show filtered result
         qim3d.viz.slices_grid(filtered_vol, num_slices=5)
         ```
-        ![original volume](../../assets/screenshots/pipeline_original.png)
-        ![original volume](../../assets/screenshots/pipeline_middlestep.png)
-        ![filtered volume](../../assets/screenshots/pipeline_processed.png)
+        ![original volume](../assets/screenshots/pipeline_original.png)
+        ![original volume](../assets/screenshots/pipeline_middlestep.png)
+        ![filtered volume](../assets/screenshots/pipeline_processed.png)
 
     """
 
@@ -429,8 +429,8 @@ def gaussian(
         qim3d.viz.slices_grid(vol, n_slices=5, display_figure=True)
         qim3d.viz.slices_grid(vol_filtered, n_slices=5, display_figure=True)
         ```
-        ![gaussian-filter-before](../../assets/screenshots/gaussian_filter_original.png)
-        ![gaussian-filter-after](../../assets/screenshots/gaussian_filter_processed.png)
+        ![gaussian-filter-before](../assets/screenshots/gaussian_filter_original.png)
+        ![gaussian-filter-after](../assets/screenshots/gaussian_filter_processed.png)
 
     """
 
@@ -472,8 +472,8 @@ def sobel(vol: np.ndarray, dask: bool = False):
         qim3d.viz.slices_grid(vol, num_slices=5)
         qim3d.viz.slices_grid(filtered_vol, num_slices=5)
         ```
-        ![sobel-filter-before](../../assets/screenshots/sobel_filter_original.png)
-        ![sobel-filter-after](../../assets/screenshots/pipeline_middlestep.png)
+        ![sobel-filter-before](../assets/screenshots/sobel_filter_original.png)
+        ![sobel-filter-after](../assets/screenshots/pipeline_middlestep.png)
 
     """
     if dask:
@@ -531,8 +531,8 @@ def median(
         qim3d.viz.slices_grid(noisy_vol, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         qim3d.viz.slices_grid(vol_filtered, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         ```
-        ![median-filter-before](../../assets/screenshots/median_filter_original.png)
-        ![median-filter-after](../../assets/screenshots/median_filter_processed.png)
+        ![median-filter-before](../assets/screenshots/median_filter_original.png)
+        ![median-filter-after](../assets/screenshots/median_filter_processed.png)
 
     """
     if size is None:
@@ -589,8 +589,8 @@ def maximum(
         qim3d.viz.slices_grid(vol, n_slices=5, display_figure=True)
         qim3d.viz.slices_grid(vol_filtered, n_slices=5, display_figure=True)
         ```
-        ![maximum-filter-before](../../assets/screenshots/maximum_filter_original.png)
-        ![maximum-filter-after](../../assets/screenshots/maximum_filter_processed.png)
+        ![maximum-filter-before](../assets/screenshots/maximum_filter_original.png)
+        ![maximum-filter-after](../assets/screenshots/maximum_filter_processed.png)
 
     """
     if size is None:
@@ -646,8 +646,8 @@ def minimum(
         qim3d.viz.slices_grid(vol, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         qim3d.viz.slices_grid(vol_filtered, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         ```
-        ![minimum-filter-before](../../assets/screenshots/minimum_filter_original.png)
-        ![minimum-filter-after](../../assets/screenshots/minimum_filter_processed.png)
+        ![minimum-filter-before](../assets/screenshots/minimum_filter_original.png)
+        ![minimum-filter-after](../assets/screenshots/minimum_filter_processed.png)
 
     """
     if size is None:
@@ -697,8 +697,8 @@ def tophat(volume: np.ndarray, dask: bool = False, **kwargs):
         qim3d.viz.slices_grid(vol, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         qim3d.viz.slices_grid(vol_filtered, n_slices=5, slice_positions = [10, 31, 63, 95, 120], display_figure=True)
         ```
-        ![tophat-filter-before](../../assets/screenshots/tophat_filter_original.png)
-        ![tophat-filter-after](../../assets/screenshots/tophat_filter_processed.png)
+        ![tophat-filter-before](../assets/screenshots/tophat_filter_original.png)
+        ![tophat-filter-after](../assets/screenshots/tophat_filter_processed.png)
 
     """
 

--- a/qim3d/generate/_aggregators.py
+++ b/qim3d/generate/_aggregators.py
@@ -209,14 +209,14 @@ def _volume_collection(
         ```python
         qim3d.viz.slicer(volume_collection)
         ```
-        ![synthetic_collection](../../assets/screenshots/synthetic_collection_default.gif)
+        ![synthetic_collection](../assets/screenshots/synthetic_collection_default.gif)
 
         ```python
         # Visualize labels
         cmap = qim3d.viz.colormaps.segmentation(num_labels=n_volumes)
         qim3d.viz.slicer(labels, color_map=cmap, value_max=n_volumes)
         ```
-        ![synthetic_collection](../../assets/screenshots/synthetic_collection_default_labels.gif)
+        ![synthetic_collection](../assets/screenshots/synthetic_collection_default_labels.gif)
 
     Example:
         ```python
@@ -269,7 +269,7 @@ def _volume_collection(
         # Visualize slices
         qim3d.viz.slices_grid(volume_collection, num_slices=15)
         ```
-        ![synthetic_collection_cylinder](../../assets/screenshots/synthetic_collection_cylinder_slices.png)
+        ![synthetic_collection_cylinder](../assets/screenshots/synthetic_collection_cylinder_slices.png)
 
     Example:
         ```python
@@ -299,7 +299,7 @@ def _volume_collection(
         # Visualize slices
         qim3d.viz.slices_grid(volume_collection, num_slices=15, slice_axis=1)
         ```
-        ![synthetic_collection_tube](../../assets/screenshots/synthetic_collection_tube_slices.png)
+        ![synthetic_collection_tube](../assets/screenshots/synthetic_collection_tube_slices.png)
 
     """
 
@@ -591,14 +591,14 @@ def volume_collection(
         ```python
         qim3d.viz.slicer(volume_collection)
         ```
-        ![synthetic_collection](../../assets/screenshots/synthetic_collection_default.gif)
+        ![synthetic_collection](../assets/screenshots/synthetic_collection_default.gif)
 
         ```python
         # Visualize labels
         cmap = qim3d.viz.colormaps.segmentation(n_labels=n_volumes)
         qim3d.viz.slicer(labels, colormap=cmap, max_value=n_volumes)
         ```
-        ![synthetic_collection](../../assets/screenshots/synthetic_collection_default_labels.gif)
+        ![synthetic_collection](../assets/screenshots/synthetic_collection_default_labels.gif)
 
     Example: Collection of fiber-like structures
         ```python
@@ -626,7 +626,7 @@ def volume_collection(
         # Visualize slices
         qim3d.viz.slices_grid(volume_collection, num_slices=15)
         ```
-        ![synthetic_collection_cylinder](../../assets/screenshots/synthetic_collection_cylinder_slices.png)
+        ![synthetic_collection_cylinder](../assets/screenshots/synthetic_collection_cylinder_slices.png)
 
     Example: Create a collection of tubular (hollow) structures
         ```python
@@ -654,7 +654,7 @@ def volume_collection(
         # Visualize slices
         qim3d.viz.slices_grid(volume_collection, num_slices=15, slice_axis=1)
         ```
-        ![synthetic_collection_tube](../../assets/screenshots/synthetic_collection_tube_slices.png)
+        ![synthetic_collection_tube](../assets/screenshots/synthetic_collection_tube_slices.png)
 
     Example: Using predefined volumes
         ```python

--- a/qim3d/generate/_generators.py
+++ b/qim3d/generate/_generators.py
@@ -129,7 +129,7 @@ def background(
         ```python
         qim3d.viz.slices_grid(noisy_collection, num_slices=10, color_bar=True, color_bar_style="large")
         ```
-        ![synthetic_noisy_collection_slices](../../assets/screenshots/synthetic_noisy_collection_slices_2.png)
+        ![synthetic_noisy_collection_slices](../assets/screenshots/synthetic_noisy_collection_slices_2.png)
 
     Example:
         ```python
@@ -151,7 +151,7 @@ def background(
 
         qim3d.viz.slices_grid(noisy_collection, num_slices=10, color_bar=True, color_bar_style="large")
         ```
-        ![synthetic_noisy_collection_slices](../../assets/screenshots/synthetic_noisy_collection_slices_3.png)
+        ![synthetic_noisy_collection_slices](../assets/screenshots/synthetic_noisy_collection_slices_3.png)
 
     """
     # Ensure dtype is a valid NumPy type
@@ -327,7 +327,7 @@ def volume(
         # Visualize slices
         qim3d.viz.slices_grid(vol, value_min = 0, value_max = 255, num_slices = 15)
         ```
-        ![synthetic_blob](../../assets/screenshots/synthetic_blob_slices.png)
+        ![synthetic_blob](../assets/screenshots/synthetic_blob_slices.png)
 
     Example:
         ```python
@@ -353,7 +353,7 @@ def volume(
         # Visualize slices
         qim3d.viz.slices_grid(vol, num_slices=15, slice_axis=1)
         ```
-        ![synthetic_blob_cylinder_slice](../../assets/screenshots/synthetic_blob_cylinder_slice.png)
+        ![synthetic_blob_cylinder_slice](../assets/screenshots/synthetic_blob_cylinder_slice.png)
 
     Example:
         ```python
@@ -377,7 +377,7 @@ def volume(
         # Visualize
         qim3d.viz.slices_grid(vol, num_slices=15)
         ```
-        ![synthetic_blob_tube_slice](../../assets/screenshots/synthetic_blob_tube_slice.png)
+        ![synthetic_blob_tube_slice](../assets/screenshots/synthetic_blob_tube_slice.png)
 
     """
     # Control
@@ -566,7 +566,7 @@ class ParameterVisualizer:
 
         viz = qim3d.generate.ParameterVisualizer()
         ```
-        ![paramter_visualizer](../../assets/screenshots/viz-synthetic_parameters.gif)
+        ![paramter_visualizer](../assets/screenshots/viz-synthetic_parameters.gif)
 
     Accessing the current volume:
             The most recently generated 3D volume can be retrieved at any time using the `.get_volume()` method:

--- a/qim3d/generate/_shapes.py
+++ b/qim3d/generate/_shapes.py
@@ -212,7 +212,7 @@ def berry(
         # Display slices of the labels
         qim3d.viz.slices_grid(labels, colormap=cmap, max_value=num_druplets)
         ```
-        ![synthetic_berry_slices](../../assets/screenshots/synthetic_raspberry_slices.png)
+        ![synthetic_berry_slices](../assets/screenshots/synthetic_raspberry_slices.png)
 
     """
     # Validate inputs
@@ -483,7 +483,7 @@ def rope(
         # Display slices of the labels
         qim3d.viz.slices_grid(labels, colormap=cmap, max_value=num_threads)
         ```
-        ![synthetic_rope_labels_slices](../../assets/screenshots/synthetic_rope_slices.png)
+        ![synthetic_rope_labels_slices](../assets/screenshots/synthetic_rope_slices.png)
 
     """
     # Validate inputs

--- a/qim3d/gui/annotation_tool.py
+++ b/qim3d/gui/annotation_tool.py
@@ -16,7 +16,7 @@ annotation_tool = qim3d.gui.annotation_tool.Interface()
 # We can directly pass the image we loaded to the interface
 app = annotation_tool.launch(vol[0])
 ```
-![gui-annotation_tool](../../assets/screenshots/gui-annotation_tool.gif)
+![gui-annotation_tool](../assets/screenshots/gui-annotation_tool.gif)
 
 """
 

--- a/qim3d/gui/layers2d.py
+++ b/qim3d/gui/layers2d.py
@@ -13,7 +13,7 @@ import qim3d
 layers = qim3d.gui.layers2d.Interface()
 app = layers.launch()
 ```
-![gui-layers](../../assets/screenshots/GUI-layers.png)
+![gui-layers](../assets/screenshots/GUI-layers.png)
 
 """
 

--- a/qim3d/io/_downloader.py
+++ b/qim3d/io/_downloader.py
@@ -146,7 +146,7 @@ class Downloader:
 
         qim3d.viz.slicer_orthogonal(data, colormap="magma")
         ```
-        ![cowry shell](../../assets/screenshots/cowry_shell_slicer.gif)
+        ![cowry shell](../assets/screenshots/cowry_shell_slicer.gif)
     """
 
     def __init__(self):

--- a/qim3d/mesh/_common_mesh_methods.py
+++ b/qim3d/mesh/_common_mesh_methods.py
@@ -140,7 +140,7 @@ def from_volume(
         # Visualize the generated blob
         qim3d.viz.volumetric(synthetic_blob)
         ```
-        ![pygel3d_visualization_vol](../../assets/screenshots/viz-pygel_mesh_vol.png){width='300', length='200'}
+        ![pygel3d_visualization_vol](../assets/screenshots/viz-pygel_mesh_vol.png){width='300', length='200'}
 
         ```python
         # Convert the 3D numpy array to a mesh object
@@ -149,7 +149,7 @@ def from_volume(
         # Visualize the generated mesh
         qim3d.viz.mesh(mesh)
         ```
-        ![pygel3d_visualization_mesh](../../assets/screenshots/viz-pygel_mesh.png){width='300', length='200'}
+        ![pygel3d_visualization_mesh](../assets/screenshots/viz-pygel_mesh.png){width='300', length='200'}
 
     """
 

--- a/qim3d/operations/_common_operations_methods.py
+++ b/qim3d/operations/_common_operations_methods.py
@@ -40,7 +40,7 @@ def remove_background(
         vol = qim3d.examples.cement_128x128x128
         fig1 = qim3d.viz.slices_grid(vol, value_min=0, value_max=255, num_slices=5, display_figure=True)
         ```
-        ![operations-remove_background_before](../../assets/screenshots/operations-remove_background_before.png)
+        ![operations-remove_background_before](../assets/screenshots/operations-remove_background_before.png)
 
         ```python
         vol_filtered  = qim3d.operations.remove_background(vol,
@@ -48,7 +48,7 @@ def remove_background(
                                                               background="bright")
         fig2 = qim3d.viz.slices_grid(vol_filtered, value_min=0, value_max=255, num_slices=5, display_figure=True)
         ```
-        ![operations-remove_background_after](../../assets/screenshots/operations-remove_background_after.png)
+        ![operations-remove_background_after](../assets/screenshots/operations-remove_background_after.png)
     """
 
     # Create a pipeline with a median filter and a tophat filter
@@ -277,13 +277,13 @@ def make_hollow(
         vol = qim3d.generate.volume(noise_scale = 0.01)
         qim3d.viz.slicer(vol)
         ```
-        ![synthetic_collection](../../assets/screenshots/hollow_slicer_1.gif)
+        ![synthetic_collection](../assets/screenshots/hollow_slicer_1.gif)
         ```python
         # Hollow volume and visualize it
         vol_hollowed = qim3d.operations.make_hollow(vol, thickness=10)
         qim3d.viz.slicer(vol_hollowed)
         ```
-        ![synthetic_collection](../../assets/screenshots/hollow_slicer_2.gif)
+        ![synthetic_collection](../assets/screenshots/hollow_slicer_2.gif)
     """
     # Create base mask
     vol_mask_base = volume > 0

--- a/qim3d/operations/_slicing_operations.py
+++ b/qim3d/operations/_slicing_operations.py
@@ -320,7 +320,7 @@ def get_random_slice(
         vol = qim3d.examples.shell_225x128x128
         qim3d.viz.slices_grid(vol)
         ```
-        ![Normal slices](../../assets/screenshots/random_slice-before.png)
+        ![Normal slices](../assets/screenshots/random_slice-before.png)
 
         ```python
         random_slices = []
@@ -331,7 +331,7 @@ def get_random_slice(
         qim3d.viz.slices_grid(np.array(random_slices))
 
         ```
-        ![Random slices](../../assets/screenshots/random_slice-after.png)
+        ![Random slices](../assets/screenshots/random_slice-after.png)
     """
 
     if seed is not None:

--- a/qim3d/operations/_volume_operations.py
+++ b/qim3d/operations/_volume_operations.py
@@ -226,7 +226,7 @@ def shear3d(
 
         qim3d.viz.slicer(vol, slice_axis=1)
         ```
-        ![warp_box](../../assets/screenshots/warp_box_1.png)
+        ![warp_box](../assets/screenshots/warp_box_1.png)
         ```python
         # Shear the volume by 20% factor in x-direction along z-axis
         factor = 0.2
@@ -235,7 +235,7 @@ def shear3d(
 
         qim3d.viz.slicer(sheared_vol, slice_axis=1)
         ```
-        ![warp_box_shear](../../assets/screenshots/warp_box_shear.png)
+        ![warp_box_shear](../assets/screenshots/warp_box_shear.png)
     """
     assert len(volume.shape) == 3, "Volume must be three-dimensional."
     assert isinstance(order, int), "Order must be an integer."
@@ -325,13 +325,13 @@ def curve_warp(
         vol[:,40:60, 40:60] = 1
         qim3d.viz.slicer(vol, slice_axis=1)
         ```
-        ![warp_box_long](../../assets/screenshots/warp_box_long.png)
+        ![warp_box_long](../assets/screenshots/warp_box_long.png)
         ```python
         # Warp the box along the x dimension
         warped_volume = qim3d.operations.curve_warp(vol, x_amp=10, x_periods=4)
         qim3d.viz.slicer(warped_volume, slice_axis=1)
         ```
-        ![warp_box_curved](../../assets/screenshots/warp_box_curve.png)
+        ![warp_box_curved](../assets/screenshots/warp_box_curve.png)
     """
     assert len(volume.shape) == 3, "Volume must be three-dimensional."
     assert isinstance(order, int), "Order must be an integer."
@@ -407,7 +407,7 @@ def stretch(
 
         qim3d.viz.slicer(vol)
         ```
-        ![warp_box](../../assets/screenshots/warp_box_0.png)
+        ![warp_box](../assets/screenshots/warp_box_0.png)
 
         ```python
         # Stretch the box along the x dimension
@@ -417,7 +417,7 @@ def stretch(
         ```
         (100, 100, 140)
 
-        ![warp_box_stretch](../../assets/screenshots/warp_box_stretch.png)
+        ![warp_box_stretch](../assets/screenshots/warp_box_stretch.png)
         ```python
         # Squeeze the box along the y dimension
         squeezed_volume = qim3d.operations.stretch(vol, x_stretch=-20)
@@ -426,7 +426,7 @@ def stretch(
         ```
         (100, 100, 60)
 
-        ![warp_box_squeeze](../../assets/screenshots/warp_box_squeeze.png)
+        ![warp_box_squeeze](../assets/screenshots/warp_box_squeeze.png)
     """
     assert len(volume.shape) == 3, "Volume must be three-dimensional."
     assert isinstance(order, int), "Order must be an integer."

--- a/qim3d/processing/_layers.py
+++ b/qim3d/processing/_layers.py
@@ -58,8 +58,8 @@ def segment_layers(
         plt.legend()
         plt.show()
         ```
-        ![layer_segmentation](../../assets/screenshots/layers.png)
-        ![layer_segmentation](../../assets/screenshots/segmented_layers.png)
+        ![layer_segmentation](../assets/screenshots/layers.png)
+        ![layer_segmentation](../assets/screenshots/segmented_layers.png)
     """
     if isinstance(data, np.ndarray):
         data = data.astype(np.int32)

--- a/qim3d/processing/_local_thickness.py
+++ b/qim3d/processing/_local_thickness.py
@@ -45,7 +45,7 @@ def local_thickness(
         vol = qim3d.examples.fly_150x256x256
         lt_vol = qim3d.processing.local_thickness(vol, visualize=True, axis=0)
         ```
-        ![local thickness 3d](../../assets/screenshots/local_thickness_3d.gif)
+        ![local thickness 3d](../assets/screenshots/local_thickness_3d.gif)
 
         ```python
         import qim3d
@@ -58,10 +58,10 @@ def local_thickness(
         lt_blobs = qim3d.processing.local_thickness(slice, visualize=True)
 
         ```
-        ![local thickness 2d](../../assets/screenshots/local_thickness_2d.png)
+        ![local thickness 2d](../assets/screenshots/local_thickness_2d.png)
 
     !!! info "Runtime and memory usage"
-        ![local thickness estimate time and mem](../../assets/screenshots/Local_thickness_time_mem_estimation.png)
+        ![local thickness estimate time and mem](../assets/screenshots/Local_thickness_time_mem_estimation.png)
         Performance computed on Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz.
 
     !!! quote "Reference"

--- a/qim3d/processing/_structure_tensor.py
+++ b/qim3d/processing/_structure_tensor.py
@@ -48,10 +48,10 @@ def structure_tensor(
         vol = qim3d.examples.fibers_150x150x150
         val, vec = qim3d.processing.structure_tensor(vol, visualize = True, axis = 1)
         ```
-        ![structure tensor](../../assets/screenshots/structure_tensor_visualization_fibers.gif)
+        ![structure tensor](../assets/screenshots/structure_tensor_visualization_fibers.gif)
 
     !!! info "Runtime and memory usage"
-        ![structure tensor estimate time and mem](../../assets/screenshots/Structure_tensor_time_mem_estimation.png)
+        ![structure tensor estimate time and mem](../assets/screenshots/Structure_tensor_time_mem_estimation.png)
         Performance computed on Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz.
 
     !!! quote "Reference"

--- a/qim3d/segmentation/_common_segmentation_methods.py
+++ b/qim3d/segmentation/_common_segmentation_methods.py
@@ -33,7 +33,7 @@ def watershed(
 
         fig1 = qim3d.viz.slices_grid(binary_volume, slice_axis=1, display_figure=True)
         ```
-        ![operations-watershed_before](../../assets/screenshots/operations-watershed_before.png)
+        ![operations-watershed_before](../assets/screenshots/operations-watershed_before.png)
 
         ```python
         labeled_volume, num_labels = qim3d.segmentation.watershed(binary_volume)
@@ -41,7 +41,7 @@ def watershed(
         cmap = qim3d.viz.colormaps.segmentation(num_labels)
         fig2 = qim3d.viz.slices_grid(labeled_volume, slice_axis=1, color_map=cmap, display_figure=True)
         ```
-        ![operations-watershed_after](../../assets/screenshots/operations-watershed_after.png)
+        ![operations-watershed_after](../assets/screenshots/operations-watershed_after.png)
     """
     import scipy
     import skimage

--- a/qim3d/viz/_connected_components.py
+++ b/qim3d/viz/_connected_components.py
@@ -47,8 +47,8 @@ def plot_connected_components(
         qim3d.viz.plot_cc(cc, crop=True, display_figure=True, overlay=None, num_slices=5, component_indexs=[4,6,7])
         qim3d.viz.plot_cc(cc, crop=True, display_figure=True, overlay=vol, num_slices=5, component_indexs=[4,6,7])
         ```
-        ![plot_cc_no_overlay](../../assets/screenshots/plot_cc_no_overlay.png)
-        ![plot_cc_overlay](../../assets/screenshots/plot_cc_overlay.png)
+        ![plot_cc_no_overlay](../assets/screenshots/plot_cc_no_overlay.png)
+        ![plot_cc_overlay](../assets/screenshots/plot_cc_overlay.png)
 
     """
     # if no components are given, plot the first max_cc_to_plot=32 components

--- a/qim3d/viz/_data_exploration.py
+++ b/qim3d/viz/_data_exploration.py
@@ -142,7 +142,7 @@ def slices_grid(
         # Create a grid of 15 linearly spaced slices
         qim3d.viz.slices_grid(vol, n_slices=15)
         ```
-        ![Grid of slices](../../assets/screenshots/viz-slices.png)
+        ![Grid of slices](../assets/screenshots/viz-slices.png)
 
     """
     if image_size:
@@ -491,7 +491,7 @@ def slicer(
         # Visualize with a slider
         qim3d.viz.slicer(vol, colormap='bone')
     ```
-        ![viz slicer](../../assets/screenshots/viz-slicer.gif)
+        ![viz slicer](../assets/screenshots/viz-slicer.gif)
 
     """
     is_dask = isinstance(volume, da.Array)
@@ -716,7 +716,7 @@ def slicer_orthogonal(
             # View all three axes side-by-side
             qim3d.viz.slicer_orthogonal(vol, colormap="magma")
     ```
-            ![viz slicer_orthogonal](../../assets/screenshots/viz-orthogonal.gif)
+            ![viz slicer_orthogonal](../assets/screenshots/viz-orthogonal.gif)
 
     """
 
@@ -796,7 +796,7 @@ def fade_mask(
         vol = qim3d.examples.cement_128x128x128
         qim3d.viz.fade_mask(vol)
         ```
-        ![operations-edge_fade_before](../../assets/screenshots/viz-fade_mask.gif)
+        ![operations-edge_fade_before](../assets/screenshots/viz-fade_mask.gif)
 
     """
 
@@ -946,7 +946,7 @@ def chunks(zarr_path: str, **kwargs) -> widgets.VBox:
         # Visualize interactive chunks explorer
         qim3d.viz.chunks('path/to/zarr/dataset.zarr')
         ```
-        ![interactive chunks explorer](../../assets/screenshots/chunks_explorer.gif)
+        ![interactive chunks explorer](../assets/screenshots/chunks_explorer.gif)
 
     """
     # Opens the Zarr dataset - doesn't load to memory yet
@@ -1212,7 +1212,7 @@ def histogram(
         vol = qim3d.examples.bone_128x128x128
         qim3d.viz.histogram(vol)
         ```
-        ![viz histogram](../../assets/screenshots/viz-histogram-vol.png)
+        ![viz histogram](../assets/screenshots/viz-histogram-vol.png)
 
     Example: Histogram from a single slice
         ```python
@@ -1221,7 +1221,7 @@ def histogram(
         vol = qim3d.examples.bone_128x128x128
         qim3d.viz.histogram(vol, slice_index=100, slice_axis=1, bin_style='bars', edgecolor='white')
         ```
-        ![viz histogram](../../assets/screenshots/viz-histogram-slice.png)
+        ![viz histogram](../assets/screenshots/viz-histogram-slice.png)
 
     Example: Using coarseness for faster computation
         ```python
@@ -1230,7 +1230,7 @@ def histogram(
         vol = qim3d.examples.bone_128x128x128
         qim3d.viz.histogram(vol, coarseness=2, kde=True, log_scale=True)
         ```
-        ![viz histogram](../../assets/screenshots/viz-histogram-coarse.png)
+        ![viz histogram](../assets/screenshots/viz-histogram-coarse.png)
 
     """
     if not (0 <= slice_axis < volume.ndim):
@@ -1658,7 +1658,7 @@ def line_profile(
         vol = qim3d.examples.bone_128x128x128
         qim3d.viz.line_profile(vol)
         ```
-        ![viz histogram](../../assets/screenshots/viz-line_profile.gif)
+        ![viz histogram](../assets/screenshots/viz-line_profile.gif)
 
     """
 
@@ -1783,7 +1783,7 @@ def threshold(
         # Visualize interactive thresholding
         qim3d.viz.threshold(vol)
         ```
-        ![interactive threshold](../../assets/screenshots/interactive_thresholding.gif)
+        ![interactive threshold](../assets/screenshots/interactive_thresholding.gif)
 
     """
 
@@ -2377,7 +2377,7 @@ def compare_volumes(
 
         qim3d.viz.compare_volumes(vol1, vol2, volumetric_visualization=True)
         ```
-        ![volume_comparison](../../assets/screenshots/viz-compare_volumes.png)
+        ![volume_comparison](../assets/screenshots/viz-compare_volumes.png)
 
     """
 
@@ -2643,7 +2643,7 @@ def iso_surface(volume: np.ndarray, colormap: str = "Magma") -> None:
         vol = qim3d.generate.volume(noise_scale=0.020)
         qim3d.viz.iso_surface(vol)
         ```
-        ![volume_comparison](../../assets/screenshots/iso_surface.gif)
+        ![volume_comparison](../assets/screenshots/iso_surface.gif)
 
     """
     IsoSurface(volume, colormap)
@@ -2715,7 +2715,7 @@ def export_rotation(
 
         qim3d.viz.export_rotation('test.gif', vol, show=True)
         ```
-        ![export_rotation_defaults](../../assets/screenshots/export_rotation_defaults.gif)
+        ![export_rotation_defaults](../assets/screenshots/export_rotation_defaults.gif)
 
     Example:
         Creation of a .webm file with specified parameters of a generated volume in the shape of a tube.
@@ -2734,7 +2734,7 @@ def export_rotation(
                                   camera_focus = 'center',
                                   show = True)
         ```
-        ![export_rotation_video](../../assets/screenshots/export_rotation_video.gif)
+        ![export_rotation_video](../assets/screenshots/export_rotation_video.gif)
 
     """
     if not (
@@ -3307,7 +3307,7 @@ def planes(
         # Launch the interactive 3D plane viewer
         qim3d.viz.planes(vol, colormap='plasma')
         ```
-        ![viz planes](../../assets/screenshots/viz-planes.gif)
+        ![viz planes](../assets/screenshots/viz-planes.gif)
 
     """
     VolumePlaneSlicer(
@@ -3540,7 +3540,7 @@ def overlay(
 
         qim3d.viz.overlay(vol, labeled_volume, colormaps=('grey', segm_cmap), volume2_values=(0, num_labels))
         ```
-        ![viz overlay](../../assets/screenshots/viz-overlay.gif)
+        ![viz overlay](../assets/screenshots/viz-overlay.gif)
 
     """
     if volume1.ndim != 3:

--- a/qim3d/viz/_detection.py
+++ b/qim3d/viz/_detection.py
@@ -50,7 +50,7 @@ def circles(
         # Visualize detected blobs with circles method
         qim3d.viz.circles(blobs, vol, alpha=0.8, color='blue')
         ```
-        ![blob detection](../../assets/screenshots/blob_detection.gif)
+        ![blob detection](../assets/screenshots/blob_detection.gif)
     """
 
     def _slicer(z_slice):

--- a/qim3d/viz/_k3d.py
+++ b/qim3d/viz/_k3d.py
@@ -283,12 +283,12 @@ def mesh(
         # Visualize the generated mesh
         qim3d.viz.mesh(mesh)
         ```
-        ![pygel3d_visualization](../../assets/screenshots/viz-pygel_mesh.png)
+        ![pygel3d_visualization](../assets/screenshots/viz-pygel_mesh.png)
 
         ```python
         qim3d.viz.mesh(mesh, backend='k3d', wireframe=False, flat_shading=False)
         ```
-        ![k3d_visualization](../../assets/screenshots/viz-k3d_mesh.png)
+        ![k3d_visualization](../assets/screenshots/viz-k3d_mesh.png)
     """
 
     if len(mesh.vertices()) > 100000:

--- a/qim3d/viz/_local_thickness.py
+++ b/qim3d/viz/_local_thickness.py
@@ -55,7 +55,7 @@ def local_thickness(
         lt_fly = qim3d.processing.local_thickness(fly)
         qim3d.viz.local_thickness(fly, lt_fly, axis=0)
         ```
-        ![local thickness 3d](../../assets/screenshots/local_thickness_3d.gif)
+        ![local thickness 3d](../assets/screenshots/local_thickness_3d.gif)
     """
 
     def _local_thickness(image, image_lt, show, figsize, axis=None, slice_index=None):

--- a/qim3d/viz/_mesh.py
+++ b/qim3d/viz/_mesh.py
@@ -64,17 +64,11 @@ def mesh(
         # Visualize the generated mesh
         qim3d.viz.mesh(mesh)
         ```
-        ![pygel3d_visualization](../../assets/screenshots/viz-pygel_mesh.png)
+        ![pygel3d_visualization](../assets/screenshots/viz-pygel_mesh.png)
 
         ```python
         qim3d.viz.mesh(mesh, backend='k3d', wireframe=False, flat_shading=False)
         ```
-        [k3d_visualization](../../assets/screenshots/sphere.html)
-        <div class="scene">
-            <iframe src="http://127.0.0.1:8000/qim3d/assets/screenshots/sphere.html" width="100%" height="500" frameborder="0"></iframe>
-        </div>
-
-
     """
 
     if isinstance(mesh, (VolumeMesh, SurfaceMesh)):

--- a/qim3d/viz/_structure_tensor.py
+++ b/qim3d/viz/_structure_tensor.py
@@ -89,7 +89,7 @@ def vectors(
 
             qim3d.viz.vectors(vol, vec, axis=2, interactive=True)
     ```
-            ![structure tensor](../../assets/screenshots/structure_tensor_visualization.gif)
+            ![structure tensor](../assets/screenshots/structure_tensor_visualization.gif)
 
     """
 

--- a/qim3d/viz/colormaps/_qim_colors.py
+++ b/qim3d/viz/colormaps/_qim_colors.py
@@ -18,6 +18,6 @@ Example:
 
     display(qim3d.viz.colormaps.qim)
     ```
-    ![colormap objects](../../assets/screenshots/viz-colormaps-qim.png)
+    ![colormap objects](../assets/screenshots/viz-colormaps-qim.png)
 """
 colormaps.register(qim)

--- a/qim3d/viz/colormaps/_segmentation.py
+++ b/qim3d/viz/colormaps/_segmentation.py
@@ -81,7 +81,7 @@ def segmentation(
 
     Tip:
         The `min_dist` parameter can be used to control the distance between neighboring colors.
-        ![colormap objects mind_dist](../../assets/screenshots/viz-colormaps-min_dist.gif)
+        ![colormap objects mind_dist](../assets/screenshots/viz-colormaps-min_dist.gif)
 
     Example:
         ```python
@@ -97,7 +97,7 @@ def segmentation(
         display(cmap_earth)
         display(cmap_ocean)
         ```
-        ![colormap objects](../../assets/screenshots/viz-colormaps-objects-all.png)
+        ![colormap objects](../assets/screenshots/viz-colormaps-objects-all.png)
 
         ```python
         import qim3d
@@ -109,7 +109,7 @@ def segmentation(
         color_map = qim3d.viz.colormaps.segmentation(n_labels, style = 'bright')
         qim3d.viz.slicer(labeled_volume, slice_axis = 1, color_map=color_map)
         ```
-        ![colormap objects](../../assets/screenshots/viz-colormaps-objects.gif)
+        ![colormap objects](../assets/screenshots/viz-colormaps-objects.gif)
     """
     from skimage import color
 


### PR DESCRIPTION
Fixes #122.

`mkdocs build` emitted 159 warnings, almost all the same off-by-one: docstrings and hand-written docs pages under `docs/` (`api_reference/`, `user_guide/`, `examples/`) linked images via `../../assets/...`, but every page that renders these lives exactly one level below `docs/`, so the correct relative path is `../assets/...` — mkdocs's own warning already named the right target for each one, and the fix is that suggestion applied consistently across all 30 affected files (25 in `qim3d/`, 5 in `docs/`).

Two more links pointed at each other's file through a nonexistent directory: `cli.md` linked `gui.md` as `../gui/gui.md` and `gui.md` linked `cli.md` as `../cli/cli.md`, though both live directly in `user_guide/` — fixed to the plain sibling filename. `installation.md`'s Windows build tools image was missing the leading `../` entirely.

One reference, in `mesh()`'s docstring, couldn't be fixed the same way: `[k3d_visualization](../../assets/screenshots/sphere.html)` points at a file that doesn't exist anywhere in the repository, correct path or not, and the accompanying `<iframe>` hardcodes `http://127.0.0.1:8000/qim3d/...`, a local dev-server address that can't work on the built docs site regardless. Removed that snippet rather than leave a link no path fixes, keeping the still-valid pygel3d screenshot right above it (now correctly `../assets/...`).

**Testing**: `mkdocs build` — 0 warnings about missing/broken links, down from 159. (59 separate `griffe: ... No type or annotation for returned value` warnings remain — pre-existing, about missing type annotations rather than links, out of scope here.) Confirmed `ruff check` and `ruff format --check` report the same pre-existing counts as `origin/main` for every file touched (95 lint findings, 0 formatting diffs) — nothing this change added, since every edit is inside markdown link text in a docstring or doc page, not executable code.